### PR TITLE
Retry Firefox install after fixing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,14 @@ elif is_ubuntu():
     ensure_firefox_from_apt()
 
 profile = find_firefox_profile()
-extension_data = get_extension_json(profile)
-for extension_id, extension_name in EXTENSIONS_TO_INSTALL.items():
-    if extension_already_installed(extension_data, extension_name):
-        continue
-    install_firefox_extension(extension_id)
+if profile is None:
+    print(
+        "Skipping Firefox extension installation because no profile was found. "
+        "Launch Firefox once to create a profile and rerun this step if needed."
+    )
+else:
+    extension_data = get_extension_json(profile)
+    for extension_id, extension_name in EXTENSIONS_TO_INSTALL.items():
+        if extension_already_installed(extension_data, extension_name):
+            continue
+        install_firefox_extension(extension_id)

--- a/utils/firefox.py
+++ b/utils/firefox.py
@@ -69,15 +69,30 @@ def setup_mozilla_repo():
 
 
 def install_regular_firefox():
+    install_command = ["sudo", "apt", "install", "-y", "firefox"]
+
+    try:
+        subprocess.run(install_command, check=True, stdout=subprocess.DEVNULL)
+        print("Firefox installed.")
+        return
+    except subprocess.CalledProcessError as e:
+        print(f"Error installing Firefox: {e}")
+
+    print("Attempting to repair APT dependencies and retry Firefox installation.")
+
     try:
         subprocess.run(
-            ["sudo", "apt", "install", "-y", "firefox"],
+            ["sudo", "apt-get", "install", "-y", "--fix-broken"],
             check=True,
             stdout=subprocess.DEVNULL,
         )
-        print("Firefox installed.")
-    except subprocess.CalledProcessError as e:
-        print(f"Error installing Firefox: {e}")
+        subprocess.run(install_command, check=True, stdout=subprocess.DEVNULL)
+        print("Firefox installed after repairing dependencies.")
+    except subprocess.CalledProcessError as repair_error:
+        print(
+            "Failed to repair dependencies for Firefox installation: "
+            f"{repair_error}"
+        )
 
 
 def purge_esr_profiles():
@@ -139,6 +154,12 @@ def extension_already_installed(extension_data, extension_name):
 
 
 def get_extension_json(profile_dir):
+    if profile_dir is None:
+        print(
+            "Firefox profile directory not provided. Skipping extension data lookup."
+        )
+        return {}
+
     extensions_file = os.path.join(profile_dir, "extensions.json")
     extensions_data = {}
 


### PR DESCRIPTION
## Summary
- retry Firefox installation after running `apt-get --fix-broken install` when the initial attempt fails
- log the repair attempt so users know the script is healing the package manager state automatically

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6906e61d432c832e861081c2bce2b5ad