### PR TITLE
Handle missing apt keys during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,30 +30,12 @@ from utils.git import configure_git
 from utils.shell import configure_shell
 from utils.ssh import configure_ssh
 from utils.vscode import configure_vscode
-from utils.web import install_software_list
+from utils.web import ensure_repositories_configured, install_software_list
 from utils.ubuntu import ensure_firefox_from_apt, purge_snapd
 
 
 if not is_debian_like():
     sys.exit("Freckles currently supports Debian and Ubuntu systems only.")
-
-apt_update_result = run("sudo apt-get update -yqq")
-if apt_update_result.returncode != 0:
-    message = apt_update_result.stderr.strip() or apt_update_result.stdout.strip()
-    sys.exit(f"Failed to refresh apt package lists: {message}")
-
-core_packages = [
-    "curl",
-    "git",
-    "ca-certificates",
-    "gnupg",
-    "lsb-release",
-]
-
-essential_install = install_with_apt(core_packages)
-if essential_install.returncode != 0:
-    message = essential_install.stderr.strip() or essential_install.stdout.strip()
-    sys.exit(f"Failed to install required base packages: {message}")
 
 software_list = [
     DebFile(
@@ -101,6 +83,30 @@ unwanted_software = [
     "cups",
     "cups-*",
 ]
+
+apt_update_result = run("sudo apt-get update -yqq")
+if apt_update_result.returncode != 0:
+    combined_output = (apt_update_result.stderr or "") + (apt_update_result.stdout or "")
+    if "NO_PUBKEY" in combined_output:
+        ensure_repositories_configured(software_list)
+        apt_update_result = run("sudo apt-get update -yqq")
+
+if apt_update_result.returncode != 0:
+    message = (apt_update_result.stderr or "").strip() or (apt_update_result.stdout or "").strip()
+    sys.exit(f"Failed to refresh apt package lists: {message}")
+
+core_packages = [
+    "curl",
+    "git",
+    "ca-certificates",
+    "gnupg",
+    "lsb-release",
+]
+
+essential_install = install_with_apt(core_packages)
+if essential_install.returncode != 0:
+    message = essential_install.stderr.strip() or essential_install.stdout.strip()
+    sys.exit(f"Failed to install required base packages: {message}")
 
 if is_ubuntu():
     purge_snapd()

--- a/utils/web.py
+++ b/utils/web.py
@@ -98,6 +98,46 @@ def get_and_install_from_download_link(link, command):
     file_name.unlink(missing_ok=True)
 
 
+def _configure_repository(repository: DebRepository) -> None:
+    download_file(repository.gpg, f"{repository.name}.gpg", overwrite=True)
+    _ensure_success(
+        run("sudo install -m 0755 -d /etc/apt/keyrings"),
+        f"Failed to create keyring directory for {repository.name}",
+    )
+    keyring_path = Path("/etc/apt/keyrings") / f"{repository.name}.gpg"
+    _ensure_success(
+        run(f"sudo gpg --dearmor --yes -o {keyring_path} {repository.name}.gpg"),
+        f"Failed to install GPG key for {repository.name}",
+    )
+    _ensure_success(
+        run(f"sudo chmod 644 {keyring_path}"),
+        f"Failed to set permissions on keyring for {repository.name}",
+    )
+    Path(f"{repository.name}.gpg").unlink(missing_ok=True)
+    repo_line = f"deb [signed-by={keyring_path}] {repository.repository}"
+    _ensure_success(
+        run(
+            f'echo "{repo_line}" | '
+            f"sudo tee /etc/apt/sources.list.d/{repository.name}.list > /dev/null"
+        ),
+        f"Failed to configure repository for {repository.name}",
+    )
+
+
+def ensure_repositories_configured(
+    software_list: List[Union[DebFile, DebRepository]]
+) -> bool:
+    configured = False
+    for software in software_list:
+        if isinstance(software, DebRepository):
+            try:
+                _configure_repository(software)
+                configured = True
+            except RuntimeError as error:
+                print(error)
+    return configured
+
+
 def install_software_list(software_list: List[Union[DebFile, DebRepository]]):
     update_result = run("sudo apt-get update -yqq")
     _ensure_success(update_result, "Failed to refresh apt package lists")
@@ -124,30 +164,7 @@ def install_software_list(software_list: List[Union[DebFile, DebRepository]]):
                 continue
             get_and_install_from_download_link(software.direct_link, software.name)
         elif isinstance(software, DebRepository):
-            download_file(software.gpg, f"{software.name}.gpg", overwrite=True)
-            _ensure_success(
-                run("sudo install -m 0755 -d /etc/apt/keyrings"),
-                f"Failed to create keyring directory for {software.name}",
-            )
-            keyring_path = Path("/etc/apt/keyrings") / f"{software.name}.gpg"
-            _ensure_success(
-                run(
-                    f"sudo gpg --dearmor --yes -o {keyring_path} {software.name}.gpg"
-                ),
-                f"Failed to install GPG key for {software.name}",
-            )
-            _ensure_success(
-                run(f"sudo chmod 644 {keyring_path}"),
-                f"Failed to set permissions on keyring for {software.name}",
-            )
-            Path(f"{software.name}.gpg").unlink(missing_ok=True)
-            repo_line = f"deb [signed-by={keyring_path}] {software.repository}"
-            _ensure_success(
-                run(
-                    f'echo "{repo_line}" | sudo tee /etc/apt/sources.list.d/{software.name}.list > /dev/null'
-                ),
-                f"Failed to configure repository for {software.name}",
-            )
+            _configure_repository(software)
             update_result = run("sudo apt-get update -yqq")
             _ensure_success(update_result, f"Failed to update apt cache for {software.name}")
             print(f"installing {software.name}")


### PR DESCRIPTION
## Summary
- add a reusable helper to configure third-party repositories and GPG keyrings
- retry the initial apt update after automatically installing known repository keys when signature errors occur

## Testing
- python -m compileall setup.py utils/web.py

------
https://chatgpt.com/codex/tasks/task_e_6906ec4d5df4832eb97cc7b5a894b6f8