### PR TITLE
Handle Spotify key rotation automatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import re
 import sys
 
 from utils.avatar import manage_avatar
@@ -30,7 +31,11 @@ from utils.git import configure_git
 from utils.shell import configure_shell
 from utils.ssh import configure_ssh
 from utils.vscode import configure_vscode
-from utils.web import ensure_repositories_configured, install_software_list
+from utils.web import (
+    ensure_repositories_configured,
+    install_software_list,
+    refresh_repository_keys,
+)
 from utils.ubuntu import ensure_firefox_from_apt, purge_snapd
 
 
@@ -65,7 +70,8 @@ software_list = [
     ),
     DebRepository(
         name="spotify",
-        gpg="https://download.spotify.com/debian/pubkey_7A3A762FAFD4A51F.gpg",
+        gpg="https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg",
+        gpg_template="https://download.spotify.com/debian/pubkey_{key_id}.gpg",
         repository="https://repository.spotify.com stable non-free",
         install_name="spotify-client",
         check_name="spotify",
@@ -88,7 +94,13 @@ apt_update_result = run("sudo apt-get update -yqq")
 if apt_update_result.returncode != 0:
     combined_output = (apt_update_result.stderr or "") + (apt_update_result.stdout or "")
     if "NO_PUBKEY" in combined_output:
-        ensure_repositories_configured(software_list)
+        missing_key_ids = {
+            match.group(1).upper()
+            for match in re.finditer(r"NO_PUBKEY\\s+([0-9A-F]+)", combined_output)
+        }
+        refreshed = refresh_repository_keys(software_list, missing_key_ids)
+        if not refreshed:
+            ensure_repositories_configured(software_list)
         apt_update_result = run("sudo apt-get update -yqq")
 
 if apt_update_result.returncode != 0:

--- a/utils/debian.py
+++ b/utils/debian.py
@@ -27,6 +27,7 @@ class DebRepository:
     repository: str
     install_name: Optional[str] = None
     check_name: Optional[str] = None
+    gpg_template: Optional[str] = None
 
 
 def run(command: str) -> subprocess.CompletedProcess[str]:

--- a/utils/web.py
+++ b/utils/web.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 import urllib.request
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Set, Union
 
 from .debian import (
     DebFile,
@@ -98,8 +98,16 @@ def get_and_install_from_download_link(link, command):
     file_name.unlink(missing_ok=True)
 
 
-def _configure_repository(repository: DebRepository) -> None:
-    download_file(repository.gpg, f"{repository.name}.gpg", overwrite=True)
+def _configure_repository(
+    repository: DebRepository, key_url: Optional[str] = None
+) -> None:
+    source_url = key_url or repository.gpg
+    try:
+        download_file(source_url, f"{repository.name}.gpg", overwrite=True)
+    except Exception as error:
+        raise RuntimeError(
+            f"Failed to download GPG key for {repository.name}: {error}"
+        ) from error
     _ensure_success(
         run("sudo install -m 0755 -d /etc/apt/keyrings"),
         f"Failed to create keyring directory for {repository.name}",
@@ -136,6 +144,34 @@ def ensure_repositories_configured(
             except RuntimeError as error:
                 print(error)
     return configured
+
+
+def refresh_repository_keys(
+    software_list: List[Union[DebFile, DebRepository]],
+    missing_key_ids: Set[str],
+) -> bool:
+    """Attempt to refresh repository keys using the provided key identifiers."""
+
+    refreshed = False
+    if not missing_key_ids:
+        return refreshed
+
+    for software in software_list:
+        if not isinstance(software, DebRepository):
+            continue
+        if not software.gpg_template:
+            continue
+        for key_id in missing_key_ids:
+            try:
+                _configure_repository(
+                    software,
+                    key_url=software.gpg_template.format(key_id=key_id),
+                )
+                refreshed = True
+                break
+            except (RuntimeError, KeyError) as error:
+                print(error)
+    return refreshed
 
 
 def install_software_list(software_list: List[Union[DebFile, DebRepository]]):


### PR DESCRIPTION
## Summary
- add support for dynamic Spotify GPG key downloads using the key ID reported by apt
- extend repository configuration to support templated key URLs and handle download failures gracefully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906ed94ee54832ebfbc41f7d9619dcb