### PR TITLE
Fix prompt path helper for arbitrary home directories

### DIFF
--- a/shell/pathname.py
+++ b/shell/pathname.py
@@ -25,14 +25,22 @@ def path_name():
 
 if __name__ == "__main__":
     assert truncate_path("~/") == "~/"
-    assert (
-        truncate_path("~/work/gitlab/evenergi/vemo/vemo-core/src")
-        == "~/work/gitlab/../vemo-core/src"
-    )
 
+    expected = "~/work/gitlab/../vemo-core/src"
+    assert truncate_path("~/work/gitlab/evenergi/vemo/vemo-core/src") == expected
     assert (
-        truncate_path("/home/alex/work/gitlab/evenergi/vemo/vemo-core/src")
-        == "~/work/gitlab/../vemo-core/src"
+        truncate_path(
+            str(
+                Path.home()
+                / "work"
+                / "gitlab"
+                / "evenergi"
+                / "vemo"
+                / "vemo-core"
+                / "src"
+            )
+        )
+        == expected
     )
 
     assert truncate_path("/etc/apt/sources") == "/etc/apt/sources"


### PR DESCRIPTION
## Summary
- update the pathname prompt helper self-test to derive the home directory dynamically so it no longer fails on non-alex systems

## Testing
- python3 shell/pathname.py

------
https://chatgpt.com/codex/tasks/task_e_6906f3436a60832eaeb4bb0321d2cf35