### PR TITLE
Improve git account aliasing and SSH concierge

### DIFF
--- a/utils/accounts.py
+++ b/utils/accounts.py
@@ -40,6 +40,7 @@ class GitAccount:
     display_name: str
     email: str
     directory: str
+    alias: Optional[str] = None
     username: Optional[str] = None
     signing_key: Optional[str] = None
     op_vault: Optional[str] = None
@@ -52,6 +53,8 @@ class GitAccount:
         self.display_name = self.display_name.strip()
         self.email = self.email.strip()
         self.directory = _normalise_directory(self.directory.strip())
+        if self.alias:
+            self.alias = self.alias.strip()
         if self.username:
             self.username = self.username.strip()
         if self.signing_key:
@@ -64,15 +67,21 @@ class GitAccount:
             self.ssh_host = self.ssh_host.strip()
 
     @property
-    def slug(self) -> str:
+    def alias_slug(self) -> str:
+        if self.alias:
+            return _slugify(self.alias)
         return _slugify(f"{self.scope}-{self.provider}")
+
+    @property
+    def slug(self) -> str:
+        return self.alias_slug
 
     @property
     def ssh_alias(self) -> str:
         alias = self.ssh_host
         if alias:
             return alias
-        return f"{self.provider}.com-{self.slug}"
+        return f"{self.provider}.com-{self.alias_slug}"
 
     def as_serialisable(self) -> dict:
         data = asdict(self)
@@ -208,6 +217,12 @@ def _prompt_account(existing: Optional[GitAccount] = None) -> GitAccount:
     display_default = existing.display_name if existing else scope.title()
     display_name = _prompt("Commit author name", default=display_default)
 
+    alias_default = existing.alias if existing and existing.alias else scope
+    alias_value = _prompt(
+        "Short alias for this identity (used in SSH/git config)",
+        default=alias_default,
+    )
+
     username_default = existing.username if existing and existing.username else ""
     username = _prompt("Account username", default=username_default, allow_empty=True)
 
@@ -262,6 +277,7 @@ def _prompt_account(existing: Optional[GitAccount] = None) -> GitAccount:
         display_name=display_name,
         email=email,
         directory=directory,
+        alias=alias_value or None,
         username=username or None,
         signing_key=signing_key or None,
         op_vault=op_vault,
@@ -276,9 +292,10 @@ def _prompt_default_account(accounts: List[GitAccount], default_slug: str) -> st
     print("\nSelect the default git identity:")
     for index, account in enumerate(accounts, start=1):
         marker = "*" if account.slug == default_slug else " "
+        alias = account.alias or account.scope
         print(
             f"  {index}. [{marker}] {account.display_name} <{account.email}> "
-            f"({account.provider} @ {account.scope})"
+            f"({account.provider} @ {alias})"
         )
     while True:
         choice = _prompt("Enter the number for the default identity", default="1")
@@ -293,7 +310,8 @@ def prompt_for_account_config(existing: Optional[AccountConfig] = None) -> Accou
     accounts: List[GitAccount] = []
     if existing:
         for account in existing.accounts:
-            print(f"\nReviewing configuration for {account.provider} ({account.scope})")
+            label = account.alias or account.scope
+            print(f"\nReviewing configuration for {label} ({account.provider})")
             accounts.append(_prompt_account(existing=account))
         add_more = _prompt_yes_no("Would you like to add another git account?", default=False)
     else:
@@ -311,7 +329,7 @@ def prompt_for_account_config(existing: Optional[AccountConfig] = None) -> Accou
     for account in accounts:
         if account.slug in seen:
             raise RuntimeError(
-                "Duplicate account scopes detected. Please choose unique scopes for each provider."
+                "Duplicate account aliases detected. Please choose unique aliases for each identity."
             )
         seen.add(account.slug)
 

--- a/utils/git.py
+++ b/utils/git.py
@@ -137,7 +137,7 @@ def _summarise_accounts(config: AccountConfig) -> None:
     ]
     for account in config.accounts:
         message.append(
-            f"  - {account.provider} ({account.scope}) -> {account.directory}"
+            f"  - {account.alias_slug}: {account.provider} ({account.scope}) -> {account.directory}"
         )
     print("\n".join(message))
 

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -6,7 +6,7 @@ import sys
 import textwrap
 from typing import Dict, List, Optional, Tuple
 
-from .accounts import get_account_config, save_account_config
+from .accounts import GitAccount, get_account_config, save_account_config
 from .debian import run
 from .meta import KNOWN_HOSTS, SSH_CONFIG, SSH_DIR
 from .one_password import OnePasswordItem, ensure_op_connected, list_items
@@ -25,18 +25,28 @@ def write_known_hosts() -> None:
         KNOWN_HOSTS.write_text(known_hosts_content)
 
 
-def _score_item(account, item: OnePasswordItem) -> int:
+def _score_item(account: GitAccount, item: OnePasswordItem) -> int:
     """Return a simple relevance score between an account and 1Password item."""
 
     text = f"{item.title} {item.vault}".lower()
     score = 0
     provider = account.provider.lower()
     scope = account.scope.lower()
+    alias = (account.alias or "").lower()
+    display = account.display_name.lower()
 
     if provider and provider in text:
         score += 3
     if scope and scope in text:
         score += 2
+    if alias and alias in text:
+        score += 3
+    if display and display in text:
+        score += 1
+    alias_tokens = [token for token in alias.replace("/", " ").replace("-", " ").split() if token]
+    for token in alias_tokens:
+        if token and token in text:
+            score += 1
     if account.username and account.username.lower() in text:
         score += 2
     if "ssh" in item.title.lower():
@@ -94,6 +104,31 @@ def _prompt_for_item(account, catalog: List[OnePasswordItem]) -> Optional[Tuple[
             return selected.vault, selected.title
 
         print("Please choose a valid option.")
+
+
+def _auto_assign_items(
+    accounts: List[GitAccount], catalog: List[OnePasswordItem]
+) -> Dict[str, Tuple[str, str]]:
+    """Return automatic vault/item assignments keyed by account slug."""
+
+    assignments: Dict[str, Tuple[str, str]] = {}
+    for account in accounts:
+        ranked = sorted(
+            catalog,
+            key=lambda item: (_score_item(account, item), item.title.lower()),
+            reverse=True,
+        )
+        if not ranked:
+            continue
+        best = ranked[0]
+        best_score = _score_item(account, best)
+        if best_score <= 0:
+            continue
+        second_score = _score_item(account, ranked[1]) if len(ranked) > 1 else None
+        unique_high = second_score is None or best_score >= (second_score + 2)
+        if best_score >= 5 or unique_high:
+            assignments[account.slug] = (best.vault, best.title)
+    return assignments
 
 
 def _ensure_config_entry(account, existing_config: str) -> str:
@@ -170,18 +205,40 @@ def configure_ssh():
     SSH_DIR.mkdir(parents=True, exist_ok=True)
 
     catalog: List[OnePasswordItem] = []
-    needs_mapping = [account for account in config.accounts if not account.op_vault or not account.op_item]
+    needs_mapping = [
+        account for account in config.accounts if not account.op_vault or not account.op_item
+    ]
 
     updated_config = False
-    if needs_mapping and interactive:
+    if needs_mapping:
         catalog = list_items()
+        auto_assignments = _auto_assign_items(needs_mapping, catalog)
+        for account in needs_mapping:
+            if account.slug in auto_assignments:
+                vault, item = auto_assignments[account.slug]
+                account.op_vault, account.op_item = vault, item
+                updated_config = True
+                print(
+                    f"Automatically mapped {account.display_name} ({account.provider})"
+                    f" -> {vault}/{item}"
+                )
+        needs_mapping = [
+            account
+            for account in needs_mapping
+            if not account.op_vault or not account.op_item
+        ]
+
+    if needs_mapping and interactive:
         for account in needs_mapping:
             selection = _prompt_for_item(account, catalog)
             if selection:
                 account.op_vault, account.op_item = selection
                 updated_config = True
     elif needs_mapping:
-        print("Skipping SSH key assignment for accounts without 1Password metadata in non-interactive mode.")
+        print(
+            "Skipping SSH key assignment for accounts without 1Password metadata "
+            "in non-interactive mode."
+        )
 
     if updated_config:
         save_account_config(config)


### PR DESCRIPTION
## Summary
- add explicit aliases to git account configuration for clearer SSH host names
- auto-detect likely 1Password SSH key matches before prompting for manual selection
- include account aliases in git configuration summaries

## Testing
- python -m compileall utils

------
https://chatgpt.com/codex/tasks/task_e_6906f57149c8832ea4c5112759bbf4d1