### PR TITLE
Show SSH sync instructions whenever 1Password fields change

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,16 @@ Mostly hand-rolled bash scripts for intalling and configuring my system.
 - installs and configures git, including both my personal and work configs with `--git`
   - ships helper aliases like `git fs` for a clean branch reset, `git rb` for
     remote branch discovery, and `git db` for default-branch detection
-  - onboarding walks through each git identity (personal, work, etc.), saves the
-    answers, and keeps the includes in sync with future edits
-  - generates SSH configs and keys for every account when 1Password metadata is
-    provided
+- onboarding walks through each git identity (personal, work, etc.), saves the
+  answers, and keeps the includes in sync with future edits
+  - provisions SSH keys automatically when 1Password lacks them, stores the new
+    material in 1Password, and prints the public key ready to paste into
+    GitHub/GitLab
+  - generates and exports per-identity GPG signing keys only when 1Password does
+    not already contain them, updating git config and 1Password at the same time
+  - see [Git Identity Concierge Guide](docs/git-identity-concierge.md) for
+    manual onboarding steps or recovery when metadata needs to be created or
+    fixed
 - installs and configures brew with `--brew`
   - python 3 is installed with brew and set as the default python interpreter
   - node is installed with brew

--- a/docs/git-identity-concierge.md
+++ b/docs/git-identity-concierge.md
@@ -1,0 +1,145 @@
+# Git Identity Concierge Guide
+
+This guide documents the end-to-end process for onboarding a git identity so
+that SSH access, commit signing, and 1Password storage all stay in sync. It is
+written for identities managed through the Freckles onboarding flow.
+
+> **Note**
+> Running `freckles configure git` followed by `freckles configure ssh` now
+> generates missing SSH/GPG keys, imports existing material from 1Password when
+> present, and prints the public data to paste into GitHub/GitLab. The checklist
+> below remains a reference for manual recovery or environments where the
+> automation cannot run.
+
+## 1. Gather prerequisites
+
+1. Ensure the 1Password CLI (`op`) is installed and authenticated (`op signin`).
+2. Confirm that you know which Freckles git identity you are updating. You will
+   need the alias slug (for example `personal-github` or `airev-gitlab`).
+3. Locate the matching 1Password item that stores metadata for this account.
+   The Freckles scripts expect an item per identity with the vault/item names
+   recorded in `~/.config/freckles/accounts.json`.
+
+## 2. Generate or import the SSH key material
+
+1. Decide whether you are creating a new SSH key or importing an existing one.
+2. For a new key, run:
+
+   ```bash
+   ssh-keygen -t ed25519 -C "<email-for-the-identity>" -f ~/.ssh/<alias>
+   ```
+
+   Replace `<alias>` with something recognisable (e.g. `airev-gitlab`).
+3. If you already have a key, locate the private key (`id_ed25519`) and the
+   matching public key (`id_ed25519.pub`).
+4. Store the keys in `~/.ssh/`. Use `chmod 600` on the private key and
+   `chmod 644` on the public key if needed.
+
+## 3. Upload the SSH key to GitLab
+
+1. Copy the contents of the public key file:
+
+   ```bash
+   cat ~/.ssh/<alias>.pub | pbcopy   # or use xclip/wl-copy on Linux
+   ```
+
+2. Navigate to **GitLab → User Settings → SSH Keys**.
+3. Paste the public key, give it a descriptive title (e.g. `alex@laptop`), and
+   save.
+4. Verify SSH connectivity:
+
+   ```bash
+   ssh -T git@gitlab.com
+   ```
+
+   You should see a success greeting referencing your GitLab username.
+
+## 4. Persist the SSH key in 1Password
+
+1. Open the relevant 1Password item (for example `AI-Rev.net/gitlab token`).
+2. Add or update the following fields:
+
+   | Section | Field name     | Content                               |
+   |---------|----------------|----------------------------------------|
+   | `ssh`   | `private`      | The full private key block             |
+   | `ssh`   | `public`       | The SSH public key copied in step 3    |
+   | `ssh`   | `fingerprint`  | Output of `ssh-keygen -lf ~/.ssh/<alias>.pub` |
+
+   If the `ssh` section does not exist, create it as a new section first.
+3. Save the item. The Freckles tooling will now find `ssh.public` when it
+   provisions SSH config files.
+
+## 5. Configure commit signing (GPG)
+
+1. Check whether a GPG key already exists for the identity:
+
+   ```bash
+   gpg --list-secret-keys --keyid-format LONG "<email-for-the-identity>"
+   ```
+
+2. If you need to create a new key:
+
+   ```bash
+   gpg --full-generate-key
+   ```
+
+   - Choose **(1) RSA and RSA** or **(4) EdDSA and Ed25519**.
+   - Use at least a 4096-bit RSA key if selecting RSA.
+   - Set the uid email address to match the git identity.
+3. After generation, grab the long key ID:
+
+   ```bash
+   gpg --list-secret-keys --keyid-format LONG "<email>"
+   ```
+
+   The key ID is the hex string after `sec   rsa4096/`.
+4. Export the ASCII-armored public key and add it to GitLab under
+   **User Settings → GPG Keys**:
+
+   ```bash
+   gpg --armor --export <KEY_ID> | pbcopy
+   ```
+
+5. Back in 1Password, add the following fields to the same identity item (or a
+   linked item if preferred):
+
+   | Section | Field name | Content                                    |
+   |---------|------------|---------------------------------------------|
+   | `gpg`   | `public`   | The ASCII-armored public key                |
+   | `gpg`   | `private`  | Output of `gpg --armor --export-secret-keys <KEY_ID>` |
+   | `gpg`   | `key_id`   | The long key ID (e.g. `ABCDEF1234567890`)   |
+
+   Mark the private key field as “concealed” in 1Password.
+6. Update the Freckles git account configuration (`freckles configure git`) so
+   that the `signing_key` value for the identity matches `<KEY_ID>`.
+
+## 6. Refresh Freckles-managed configuration
+
+1. Run the Freckles git configuration helper:
+
+   ```bash
+   freckles configure git
+   ```
+
+2. Confirm that `~/.gitconfig` now includes lines similar to:
+
+   ```ini
+   [includeIf "gitdir:~/airev/gitlab/**/.git"]
+     path = ~/.airev-gitlab.gitconfig
+   ```
+
+3. Inspect the generated per-identity file (`~/.airev-gitlab.gitconfig`) to
+   ensure it carries the expected `[user]` block (and `[github]` section when
+   applicable).
+4. Verify commit signing:
+
+   ```bash
+   git config --global user.signingkey
+   git commit -S --allow-empty -m "verify signing"
+   ```
+
+   Then check the commit in GitLab/GitHub to ensure it is marked as verified.
+
+Following this checklist keeps GitLab, 1Password, and the Freckles automation in
+sync for each alias, preventing missing-field errors such as the `ssh.public`
+lookup failure.

--- a/utils/git.py
+++ b/utils/git.py
@@ -12,7 +12,8 @@ from .accounts import (
     ensure_account_config,
     get_account_config as _get_account_config,
 )
-from .meta import GIT_ACCOUNTS_DIR, HOME
+from .gpg import provision_gpg_material
+from .meta import HOME
 
 
 IDENTITY_BEGIN = "# >>> freckles global identity >>>"
@@ -77,7 +78,7 @@ def _identity_lines(account: GitAccount) -> list[str]:
 def _account_include_lines(config: AccountConfig) -> list[str]:
     lines: list[str] = []
     for account in config.accounts:
-        account_config = GIT_ACCOUNTS_DIR / f"{account.slug}.gitconfig"
+        account_config = HOME / f".{account.slug}.gitconfig"
         gitdir = account.directory.rstrip("/")
         lines.append(f'[includeIf "gitdir:{gitdir}/**/.git"]')
         lines.append(f"  path = {_home_relative(account_config)}")
@@ -85,9 +86,8 @@ def _account_include_lines(config: AccountConfig) -> list[str]:
 
 
 def _write_account_configs(config: AccountConfig) -> None:
-    GIT_ACCOUNTS_DIR.mkdir(parents=True, exist_ok=True)
     for account in config.accounts:
-        config_path = GIT_ACCOUNTS_DIR / f"{account.slug}.gitconfig"
+        config_path = HOME / f".{account.slug}.gitconfig"
         sections = [
             "[user]",
             f"  name = {account.display_name}",
@@ -145,10 +145,22 @@ def _summarise_accounts(config: AccountConfig) -> None:
 def configure_git() -> AccountConfig:
     download_git_files()
     config = ensure_account_config()
+    gpg_updates = provision_gpg_material(config)
     _write_account_configs(config)
     _update_gitconfig(config)
     _ensure_git_user_config(config)
     _summarise_accounts(config)
+    if gpg_updates:
+        print(
+            "\nGPG signing keys have been generated/exported. Paste the following public keys into Git hosting services:"
+        )
+        for account, material in gpg_updates:
+            print(
+                f"\n[{account.provider} | {account.display_name} ({account.scope})] Key ID: {material.key_id}"
+            )
+            print(material.public_key)
+            if material.fingerprint:
+                print(f"Fingerprint: {material.fingerprint}")
     return config
 
 

--- a/utils/gpg.py
+++ b/utils/gpg.py
@@ -1,0 +1,249 @@
+"""Helpers to provision and export GPG material for git identities."""
+
+from __future__ import annotations
+
+import shlex
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from .accounts import AccountConfig, GitAccount, save_account_config
+from .debian import run
+from .one_password import (
+    OnePasswordField,
+    ensure_op_connected,
+    get_field_value,
+    get_item,
+    update_item_fields,
+)
+
+
+@dataclass
+class GpgMaterial:
+    """Container for exported GPG key material."""
+
+    key_id: str
+    fingerprint: str
+    public_key: str
+    private_key: str
+
+
+def _parse_secret_key(output: str) -> Optional[Tuple[str, str]]:
+    """Extract the key id and fingerprint from ``gpg --with-colons`` output."""
+
+    key_id: Optional[str] = None
+    fingerprint: Optional[str] = None
+    for line in output.splitlines():
+        parts = line.split(":")
+        if not parts:
+            continue
+        record_type = parts[0]
+        if record_type == "sec" and len(parts) > 4:
+            key_id = parts[4]
+        elif record_type == "fpr" and len(parts) > 9 and fingerprint is None:
+            fingerprint = parts[9]
+    if key_id and fingerprint:
+        return key_id, fingerprint
+    if key_id:
+        return key_id, ""
+    return None
+
+
+def _discover_existing_key(account: GitAccount) -> Optional[Tuple[str, str]]:
+    result = run(
+        f'gpg --list-secret-keys --with-colons --fingerprint "{account.email}"'
+    )
+    if result.returncode != 0:
+        return None
+    return _parse_secret_key(result.stdout or "")
+
+
+def _import_remote_key(account: GitAccount, item: Optional[Dict]) -> Optional[Tuple[str, str]]:
+    if not item:
+        return None
+
+    private_key = get_field_value(item, "gpg", "private") or ""
+    if not private_key.strip():
+        return None
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as handle:
+        temp_path = Path(handle.name)
+        handle.write(private_key.strip() + "\n")
+
+    try:
+        result = run(f"gpg --batch --import {shlex.quote(temp_path.as_posix())}")
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        print(
+            f"Failed to import GPG key for {account.display_name} "
+            f"({account.email}) from 1Password: {message}"
+        )
+        return None
+
+    return _discover_existing_key(account)
+
+
+def _generate_key(account: GitAccount) -> Optional[Tuple[str, str]]:
+    template = """
+Key-Type: RSA
+Key-Length: 4096
+Subkey-Type: RSA
+Subkey-Length: 4096
+Name-Real: {name}
+Name-Email: {email}
+Expire-Date: 0
+%no-protection
+%commit
+""".strip().format(name=account.display_name, email=account.email)
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as handle:
+        template_path = Path(handle.name)
+        handle.write(template)
+
+    command = f"gpg --batch --generate-key {shlex.quote(template_path.as_posix())}"
+    result = run(command)
+    template_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        print(
+            f"Failed to generate GPG key for {account.display_name} "
+            f"({account.email}): {message}"
+        )
+        return None
+
+    return _discover_existing_key(account)
+
+
+def _export_material(key_id: str) -> Optional[GpgMaterial]:
+    public_result = run(f"gpg --armor --export {key_id}")
+    if public_result.returncode != 0:
+        message = public_result.stderr.strip() or public_result.stdout.strip() or "unknown error"
+        print(f"Failed to export public GPG key {key_id}: {message}")
+        return None
+
+    private_result = run(f"gpg --armor --export-secret-keys {key_id}")
+    if private_result.returncode != 0:
+        message = private_result.stderr.strip() or private_result.stdout.strip() or "unknown error"
+        print(f"Failed to export private GPG key {key_id}: {message}")
+        return None
+
+    fingerprint_result = run(
+        f"gpg --with-colons --fingerprint {key_id}"
+    )
+    fingerprint = ""
+    if fingerprint_result.returncode == 0:
+        parsed = _parse_secret_key(fingerprint_result.stdout or "")
+        if parsed:
+            fingerprint = parsed[1]
+
+    return GpgMaterial(
+        key_id=key_id,
+        fingerprint=fingerprint,
+        public_key=(public_result.stdout or "").strip(),
+        private_key=(private_result.stdout or "").strip(),
+    )
+
+
+def _needs_update(item: Optional[Dict], field: str) -> bool:
+    if not item:
+        return True
+    value = get_field_value(item, "gpg", field)
+    return not value
+
+
+def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgMaterial]]:
+    """Ensure each account has exported GPG material stored in 1Password."""
+
+    eligible_accounts = [
+        account
+        for account in config.accounts
+        if account.op_vault and account.op_item
+    ]
+    if not eligible_accounts:
+        return []
+
+    ensure_op_connected()
+    updated_material: List[Tuple[GitAccount, GpgMaterial]] = []
+    config_updated = False
+
+    for account in eligible_accounts:
+        item = get_item(account.op_vault, account.op_item)
+        remote_private = (get_field_value(item, "gpg", "private") or "") if item else ""
+        details = _discover_existing_key(account)
+        generated_new_key = False
+        if details is None and remote_private.strip():
+            details = _import_remote_key(account, item)
+            if details is None:
+                continue
+        if details is None:
+            details = _generate_key(account)
+            generated_new_key = details is not None
+        if details is None:
+            continue
+
+        key_id, fingerprint = details
+        material = _export_material(key_id)
+        if material is None:
+            continue
+
+        signing_changed = False
+        if not account.signing_key or account.signing_key != key_id:
+            account.signing_key = key_id
+            config_updated = True
+            signing_changed = True
+
+        fields: List[OnePasswordField] = []
+        if _needs_update(item, "public"):
+            fields.append(
+                OnePasswordField(
+                    section="gpg",
+                    label="public",
+                    value=material.public_key + "\n",
+                )
+            )
+        if _needs_update(item, "private"):
+            fields.append(
+                OnePasswordField(
+                    section="gpg",
+                    label="private",
+                    value=material.private_key + "\n",
+                    concealed=True,
+                )
+            )
+        if _needs_update(item, "key_id") or (item and get_field_value(item, "gpg", "key_id") != key_id):
+            fields.append(
+                OnePasswordField(
+                    section="gpg",
+                    label="key_id",
+                    value=key_id,
+                )
+            )
+        if fingerprint and (
+            _needs_update(item, "fingerprint")
+            or (item and get_field_value(item, "gpg", "fingerprint") != fingerprint)
+        ):
+            fields.append(
+                OnePasswordField(
+                    section="gpg",
+                    label="fingerprint",
+                    value=fingerprint,
+                )
+            )
+
+        fields_updated = False
+        if fields:
+            fields_updated = update_item_fields(account.op_vault, account.op_item, fields)
+            if fields_updated:
+                item = get_item(account.op_vault, account.op_item)
+
+        if generated_new_key or fields_updated or signing_changed:
+            updated_material.append((account, material))
+
+    if config_updated:
+        save_account_config(config)
+
+    return updated_material

--- a/utils/one_password.py
+++ b/utils/one_password.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import json
+import os
+import shlex
+import tempfile
 import time
 from dataclasses import dataclass
 from json import JSONDecodeError
-from typing import List
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
 
 from .debian import run
 
@@ -25,6 +29,16 @@ class OnePasswordItem:
         star = " ★" if self.favorite else ""
         vault = f" ({self.vault})" if self.vault else ""
         return f"{self.title}{vault}{star}".strip()
+
+
+@dataclass
+class OnePasswordField:
+    """Representation of a 1Password field update."""
+
+    label: str
+    value: str
+    section: Optional[str] = None
+    concealed: bool = False
 
 
 def ensure_op_connected() -> None:
@@ -65,3 +79,99 @@ def list_items() -> List[OnePasswordItem]:
         )
 
     return items
+
+
+def _item_reference(vault: str, item: str) -> str:
+    if not vault:
+        return item
+    return f"{vault}/{item}"
+
+
+def get_item(vault: str, item: str) -> Optional[Dict]:
+    """Return the raw JSON payload for a 1Password item."""
+
+    reference = _item_reference(vault, item)
+    result = run(f"op item get {shlex.quote(reference)} --format json")
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        print(f"Failed to fetch 1Password item {reference}: {message}")
+        return None
+
+    try:
+        return json.loads(result.stdout or "{}")
+    except JSONDecodeError as exc:
+        print(f"Unable to parse 1Password item {reference}: {exc}")
+        return None
+
+
+def _field_matches(field: Dict, section: Optional[str], label: str) -> bool:
+    field_label = (field.get("label") or field.get("name") or "").strip().lower()
+    target_label = (label or "").strip().lower()
+    if field_label != target_label:
+        return False
+    if not section:
+        return True
+    section_info = field.get("section") or {}
+    section_id = ""
+    if isinstance(section_info, dict):
+        section_id = (section_info.get("id") or section_info.get("label") or "").strip().lower()
+    return section_id == section.strip().lower()
+
+
+def get_field_value(item: Dict, section: Optional[str], label: str) -> Optional[str]:
+    """Return the value of ``label`` inside ``section`` when available."""
+
+    fields = item.get("fields") if isinstance(item, dict) else None
+    if not isinstance(fields, Iterable):
+        return None
+    for field in fields:
+        if not isinstance(field, dict):
+            continue
+        if _field_matches(field, section, label):
+            value = field.get("value")
+            if value is None:
+                continue
+            return str(value)
+    return None
+
+
+def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]) -> bool:
+    """Update or create fields on a 1Password item.
+
+    Multi-line values are written to temporary files to avoid shell quoting
+    pitfalls when invoking the CLI.
+    """
+
+    field_entries = []
+    temp_files: List[Path] = []
+    for field in fields:
+        fd, temp_path = tempfile.mkstemp(prefix="freckles-op-")
+        os.close(fd)
+        path = Path(temp_path)
+        temp_files.append(path)
+        path.write_text(field.value)
+        parts = []
+        if field.section:
+            parts.append(f"section={field.section}")
+        parts.append(f"label={field.label}")
+        if field.concealed:
+            parts.append("type=concealed")
+        parts.append(f"value@={path.as_posix()}")
+        field_entries.append(f"--field {shlex.quote(' '.join(parts))}")
+
+    reference = _item_reference(vault, item)
+    command = " ".join([f"op item edit {shlex.quote(reference)}"] + field_entries)
+    result = run(command)
+
+    for path in temp_files:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        print(f"Failed to update 1Password item {reference}: {message}")
+        return False
+
+    return True

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -2,14 +2,26 @@
 
 from __future__ import annotations
 
+import shlex
 import sys
+import tempfile
 import textwrap
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from .accounts import GitAccount, get_account_config, save_account_config
 from .debian import run
 from .meta import KNOWN_HOSTS, SSH_CONFIG, SSH_DIR
-from .one_password import OnePasswordItem, ensure_op_connected, list_items
+from .one_password import (
+    OnePasswordField,
+    OnePasswordItem,
+    ensure_op_connected,
+    get_field_value,
+    get_item,
+    list_items,
+    update_item_fields,
+)
 
 known_hosts_content = textwrap.dedent("""
 gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
@@ -23,6 +35,172 @@ github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+V
 def write_known_hosts() -> None:
     if not KNOWN_HOSTS.exists():
         KNOWN_HOSTS.write_text(known_hosts_content)
+
+
+def _key_paths(account: GitAccount) -> Tuple[Path, Path]:
+    key_path = SSH_DIR / f"{account.slug}.{account.provider}"
+    public_path = key_path.with_suffix(".pub")
+    return key_path, public_path
+
+
+def _read_text(path: Path) -> Optional[str]:
+    try:
+        return path.read_text().strip()
+    except FileNotFoundError:
+        return None
+
+
+def _ensure_permissions(key_path: Path, public_path: Path) -> None:
+    try:
+        key_path.chmod(0o600)
+    except FileNotFoundError:
+        pass
+    try:
+        public_path.chmod(0o644)
+    except FileNotFoundError:
+        pass
+
+
+def _generate_local_key(account: GitAccount, key_path: Path, public_path: Path) -> bool:
+    SSH_DIR.mkdir(parents=True, exist_ok=True)
+    if key_path.exists():
+        key_path.unlink()
+    if public_path.exists():
+        public_path.unlink()
+
+    command = " ".join(
+        [
+            "ssh-keygen",
+            "-t",
+            "ed25519",
+            "-C",
+            shlex.quote(account.email),
+            "-f",
+            shlex.quote(key_path.as_posix()),
+            "-N",
+            "''",
+        ]
+    )
+    result = run(command)
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        print(
+            f"Failed to generate SSH key for {account.display_name} "
+            f"({account.provider}): {message}"
+        )
+        return False
+
+    _ensure_permissions(key_path, public_path)
+    return True
+
+
+def _fingerprint(public_path: Path) -> str:
+    result = run(f'ssh-keygen -lf {shlex.quote(public_path.as_posix())}')
+    if result.returncode != 0:
+        return ""
+    line = (result.stdout or "").strip().splitlines()
+    if not line:
+        return ""
+    parts = line[0].split()
+    if len(parts) >= 2:
+        return parts[1]
+    return line[0]
+
+
+def _fingerprint_from_text(public_key: str) -> str:
+    if not public_key.strip():
+        return ""
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as handle:
+        temp_path = Path(handle.name)
+        handle.write(public_key.strip() + "\n")
+
+    try:
+        return _fingerprint(temp_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
+    if not account.op_vault or not account.op_item:
+        return None
+
+    item = get_item(account.op_vault, account.op_item)
+    key_path, public_path = _key_paths(account)
+    local_private = _read_text(key_path)
+    local_public = _read_text(public_path)
+
+    remote_public = (get_field_value(item, "ssh", "public") or "") if item else ""
+    remote_private = (get_field_value(item, "ssh", "private") or "") if item else ""
+    remote_fingerprint = (get_field_value(item, "ssh", "fingerprint") or "") if item else ""
+
+    if not local_public and remote_public:
+        local_public = remote_public.strip()
+    if not local_private and remote_private:
+        local_private = remote_private.strip()
+
+    created = False
+    remote_has_material = bool(remote_public.strip() and remote_private.strip())
+
+    if not remote_has_material and (not local_public or not local_private):
+        generated = _generate_local_key(account, key_path, public_path)
+        if not generated:
+            return None
+        created = True
+        local_private = _read_text(key_path)
+        local_public = _read_text(public_path)
+
+    if not local_public or not local_private:
+        return None
+
+    _ensure_permissions(key_path, public_path)
+
+    fingerprint = ""
+    if public_path.exists():
+        fingerprint = _fingerprint(public_path)
+    if not fingerprint:
+        fingerprint = _fingerprint_from_text(local_public)
+    if not fingerprint and remote_fingerprint.strip():
+        fingerprint = remote_fingerprint.strip()
+
+    fields: List[OnePasswordField] = []
+    if not remote_public.strip() or remote_public.strip() != local_public:
+        fields.append(
+            OnePasswordField(
+                section="ssh",
+                label="public",
+                value=local_public + "\n",
+            )
+        )
+    if not remote_private.strip() or remote_private.strip() != local_private:
+        fields.append(
+            OnePasswordField(
+                section="ssh",
+                label="private",
+                value=local_private + "\n",
+                concealed=True,
+            )
+        )
+    if fingerprint and (not remote_fingerprint.strip() or remote_fingerprint.strip() != fingerprint):
+        fields.append(
+            OnePasswordField(
+                section="ssh",
+                label="fingerprint",
+                value=fingerprint,
+            )
+        )
+
+    updated = False
+    if fields:
+        updated = update_item_fields(account.op_vault, account.op_item, fields)
+
+    return SshMaterial(
+        key_path=key_path,
+        public_key=local_public,
+        fingerprint=fingerprint,
+        updated=updated or created,
+        created=created,
+    )
 
 
 def _score_item(account: GitAccount, item: OnePasswordItem) -> int:
@@ -144,11 +322,22 @@ def _ensure_config_entry(account, existing_config: str) -> str:
             AddKeysToAgent yes
             IdentityFile ~/.ssh/{key_path.name}
             User git
-    """
+        """
     )
     with SSH_CONFIG.open("a") as fh:
         fh.write(config_entry)
     return existing_config + config_entry
+
+
+@dataclass
+class SshMaterial:
+    """Details about generated SSH material for an account."""
+
+    key_path: Path
+    public_key: str
+    fingerprint: str
+    updated: bool
+    created: bool
 
 
 def _install_keys_for_account(account) -> Tuple[bool, Optional[str]]:
@@ -200,14 +389,23 @@ def configure_ssh():
     write_known_hosts()
     interactive = sys.stdin.isatty()
     config = get_account_config(interactive=interactive)
-    ensure_op_connected()
+    accounts_with_items = [
+        account for account in config.accounts if account.op_vault and account.op_item
+    ]
+    needs_mapping = [
+        account for account in config.accounts if not account.op_vault or not account.op_item
+    ]
+    if accounts_with_items or needs_mapping:
+        ensure_op_connected()
+    provisioned: List[Tuple[GitAccount, SshMaterial]] = []
+    for account in accounts_with_items:
+        material = _provision_ssh_material(account)
+        if material and (material.created or material.updated):
+            provisioned.append((account, material))
     existing_config = SSH_CONFIG.read_text() if SSH_CONFIG.exists() else ""
     SSH_DIR.mkdir(parents=True, exist_ok=True)
 
     catalog: List[OnePasswordItem] = []
-    needs_mapping = [
-        account for account in config.accounts if not account.op_vault or not account.op_item
-    ]
 
     updated_config = False
     if needs_mapping:
@@ -281,3 +479,16 @@ def configure_ssh():
         print("\nSome SSH keys could not be installed:")
         for message in failures.values():
             print(f"  - {message}")
+    if provisioned:
+        print(
+            "\nSSH key material has been synchronised with 1Password. Paste the following public keys into the matching Git hosts:"
+        )
+        for account, material in provisioned:
+            action = "Generated" if material.created else "Updated"
+            print(
+                f"\n[{account.provider} | {account.display_name} ({account.scope})] "
+                f"({action}) -> {material.key_path.with_suffix('.pub')}"
+            )
+            print(material.public_key)
+            if material.fingerprint:
+                print(f"Fingerprint: {material.fingerprint}")


### PR DESCRIPTION
## Summary
- report both newly generated and freshly synchronised SSH keys so users always receive copy-paste material
- clarify the SSH sync message to emphasise that the printed keys now map to the Git host entries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6906f8172710832e82d2e6e29041635f