### PR TITLE
Auto-create 1Password SSH placeholders

### DIFF
--- a/utils/one_password.py
+++ b/utils/one_password.py
@@ -175,3 +175,109 @@ def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]
         return False
 
     return True
+
+
+def _has_section(payload: Dict, label: str) -> bool:
+    """Return ``True`` when ``payload`` contains ``label`` section."""
+
+    sections = payload.get("sections")
+    if not isinstance(sections, Iterable):
+        return False
+    for section in sections:
+        if not isinstance(section, dict):
+            continue
+        section_label = (section.get("label") or section.get("name") or "").strip().lower()
+        section_id = (section.get("id") or "").strip().lower()
+        if label.strip().lower() in {section_label, section_id}:
+            return True
+    return False
+
+
+def _create_ssh_item(vault: str, item: str) -> bool:
+    """Create a minimal secure note prepared for SSH key material."""
+
+    parts = ["op", "item", "create", "--category", shlex.quote("Secure Note"), "--title", shlex.quote(item)]
+    if vault:
+        parts.extend(["--vault", shlex.quote(vault)])
+    parts.extend(["--section", shlex.quote("id=ssh;label=ssh")])
+
+    def _field_arg(label: str, *, concealed: bool = False) -> str:
+        components = ["section=ssh", f"label={label}"]
+        if concealed:
+            components.append("type=concealed")
+        else:
+            components.append("type=string")
+        components.append("value=")
+        return "--field " + shlex.quote(";".join(components))
+
+    parts.append(_field_arg("public"))
+    parts.append(_field_arg("private", concealed=True))
+    parts.append(_field_arg("fingerprint"))
+
+    command = " ".join(parts)
+    result = run(command)
+    if result.returncode != 0:
+        reference = _item_reference(vault, item)
+        message = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        print(f"Failed to create 1Password item {reference}: {message}")
+        return False
+    return True
+
+
+def _ensure_section(vault: str, item: str, label: str) -> bool:
+    """Ensure ``label`` section exists on ``item``."""
+
+    reference = _item_reference(vault, item)
+    section_spec = shlex.quote(f"id={label};label={label}")
+    command = f"op item edit {shlex.quote(reference)} --section {section_spec}"
+    result = run(command)
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        print(f"Failed to ensure section {label} on 1Password item {reference}: {message}")
+        return False
+    return True
+
+
+def ensure_ssh_container(vault: str, item: str) -> Optional[Dict]:
+    """Ensure ``vault``/``item`` exists with an ``ssh`` section and base fields."""
+
+    payload = get_item(vault, item)
+    if payload is None:
+        if not _create_ssh_item(vault, item):
+            return None
+        payload = get_item(vault, item)
+        if payload is None:
+            return None
+
+    if not _has_section(payload, "ssh"):
+        if not _ensure_section(vault, item, "ssh"):
+            return None
+        payload = get_item(vault, item)
+        if payload is None:
+            return None
+
+    placeholders: List[OnePasswordField] = []
+    for label, concealed in (
+        ("public", False),
+        ("private", True),
+        ("fingerprint", False),
+    ):
+        if get_field_value(payload, "ssh", label) is None:
+            value = "\n" if label != "fingerprint" else ""
+            placeholders.append(
+                OnePasswordField(
+                    section="ssh",
+                    label=label,
+                    value=value,
+                    concealed=concealed,
+                )
+            )
+
+    if placeholders:
+        if not update_item_fields(vault, item, placeholders):
+            return None
+        payload = get_item(vault, item)
+        if payload is None:
+            return None
+
+    return payload

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -17,8 +17,8 @@ from .one_password import (
     OnePasswordField,
     OnePasswordItem,
     ensure_op_connected,
+    ensure_ssh_container,
     get_field_value,
-    get_item,
     list_items,
     update_item_fields,
 )
@@ -125,14 +125,16 @@ def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
     if not account.op_vault or not account.op_item:
         return None
 
-    item = get_item(account.op_vault, account.op_item)
+    item = ensure_ssh_container(account.op_vault, account.op_item)
+    if item is None:
+        return None
     key_path, public_path = _key_paths(account)
     local_private = _read_text(key_path)
     local_public = _read_text(public_path)
 
-    remote_public = (get_field_value(item, "ssh", "public") or "") if item else ""
-    remote_private = (get_field_value(item, "ssh", "private") or "") if item else ""
-    remote_fingerprint = (get_field_value(item, "ssh", "fingerprint") or "") if item else ""
+    remote_public = get_field_value(item, "ssh", "public") or ""
+    remote_private = get_field_value(item, "ssh", "private") or ""
+    remote_fingerprint = get_field_value(item, "ssh", "fingerprint") or ""
 
     if not local_public and remote_public:
         local_public = remote_public.strip()
@@ -345,6 +347,13 @@ def _install_keys_for_account(account) -> Tuple[bool, Optional[str]]:
 
     if not account.op_vault or not account.op_item:
         return False, None
+
+    prepared = ensure_ssh_container(account.op_vault, account.op_item)
+    if prepared is None:
+        return False, (
+            f"Unable to prepare 1Password item for {account.display_name} "
+            f"({account.provider})."
+        )
 
     key_path = SSH_DIR / f"{account.slug}.{account.provider}"
     public_key = key_path.with_suffix(".pub")


### PR DESCRIPTION
## Summary
- automatically create secure-note placeholders in 1Password when SSH items are missing
- ensure SSH provisioning and installation rely on the prepared container before syncing keys

## Testing
- python -m compileall utils

------
https://chatgpt.com/codex/tasks/task_e_6906feb121f8832eb2f95a5cd3d47ace