### PR TITLE
Improve automatic provisioning of SSH vault items

### DIFF
--- a/utils/one_password.py
+++ b/utils/one_password.py
@@ -232,13 +232,30 @@ def _create_secure_note(vault: str, item: str) -> bool:
     return True
 
 
-def ensure_ssh_container(vault: str, item: str) -> Optional[Dict]:
+def ensure_ssh_container(
+    vault: str,
+    item: str,
+    *,
+    create_if_missing: bool = True,
+    initial_fields: Optional[Iterable[OnePasswordField]] = None,
+) -> Optional[Dict]:
     """Ensure ``vault``/``item`` exists with an ``ssh`` section and base fields."""
 
     payload = get_item(vault, item, suppress_missing=True)
     if payload is None:
+        if not create_if_missing:
+            reference = _item_reference(vault, item)
+            print(
+                "Unable to locate 1Password item "
+                f"{reference}. Please create it manually before continuing."
+            )
+            return None
         if not _create_secure_note(vault, item):
             return None
+        field_seed = list(initial_fields or [])
+        if field_seed:
+            if not update_item_fields(vault, item, field_seed):
+                return None
         payload = get_item(vault, item, suppress_missing=True)
         if payload is None:
             return None

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -19,6 +19,7 @@ from .one_password import (
     ensure_op_connected,
     ensure_ssh_container,
     get_field_value,
+    get_item,
     list_items,
     update_item_fields,
 )
@@ -125,9 +126,7 @@ def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
     if not account.op_vault or not account.op_item:
         return None
 
-    item = ensure_ssh_container(account.op_vault, account.op_item)
-    if item is None:
-        return None
+    item = get_item(account.op_vault, account.op_item, suppress_missing=True)
     key_path, public_path = _key_paths(account)
     local_private = _read_text(key_path)
     local_public = _read_text(public_path)
@@ -192,6 +191,25 @@ def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
             )
         )
 
+    missing_item = item is None
+    prepared = ensure_ssh_container(
+        account.op_vault,
+        account.op_item,
+        create_if_missing=missing_item,
+        initial_fields=list(fields) if missing_item else None,
+    )
+    if prepared is None:
+        return None
+    item = prepared
+
+    if missing_item:
+        # ``initial_fields`` already populated the new item with fresh material,
+        # so there is no need to rewrite the same values immediately afterwards.
+        fields = []
+        remote_public = get_field_value(item, "ssh", "public") or ""
+        remote_private = get_field_value(item, "ssh", "private") or ""
+        remote_fingerprint = get_field_value(item, "ssh", "fingerprint") or ""
+
     updated = False
     if fields:
         updated = update_item_fields(account.op_vault, account.op_item, fields)
@@ -200,7 +218,7 @@ def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
         key_path=key_path,
         public_key=local_public,
         fingerprint=fingerprint,
-        updated=updated or created,
+        updated=missing_item or updated or created,
         created=created,
     )
 
@@ -348,7 +366,11 @@ def _install_keys_for_account(account) -> Tuple[bool, Optional[str]]:
     if not account.op_vault or not account.op_item:
         return False, None
 
-    prepared = ensure_ssh_container(account.op_vault, account.op_item)
+    prepared = ensure_ssh_container(
+        account.op_vault,
+        account.op_item,
+        create_if_missing=False,
+    )
     if prepared is None:
         return False, (
             f"Unable to prepare 1Password item for {account.display_name} "


### PR DESCRIPTION
## Summary
- allow 1Password SSH provisioning to create vault items only when we have key material ready to store
- seed newly created SSH items with their generated fields instead of leaving empty placeholders
- avoid creating empty SSH items when only installing keys so operators see meaningful vault entries

## Testing
- python -m compileall utils

------
https://chatgpt.com/codex/tasks/task_e_69070859837c832eaa3737d291d64af2