### PR TITLE
Handle ambiguous 1Password item matches

### DIFF
--- a/utils/one_password.py
+++ b/utils/one_password.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import tempfile
 import time
@@ -21,6 +22,7 @@ class OnePasswordItem:
 
     title: str
     vault: str
+    identifier: str
     favorite: bool = False
 
     def label(self) -> str:
@@ -74,11 +76,69 @@ def list_items() -> List[OnePasswordItem]:
             OnePasswordItem(
                 title=entry.get("title", ""),
                 vault=vault_name,
+                identifier=entry.get("id", ""),
                 favorite=bool(entry.get("favorite", False)),
             )
         )
 
     return items
+
+
+class MultipleItemsFoundError(Exception):
+    """Raised when more than one 1Password item matches a query."""
+
+    def __init__(self, vault: str, item: str, matches: List[OnePasswordItem]):
+        self.vault = vault
+        self.item = item
+        self.matches = matches
+        resolved_vault = vault or "default"
+        super().__init__(
+            f"Multiple items matched '{item}' in vault '{resolved_vault}'."
+        )
+
+
+_ITEM_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9]{26}$")
+
+
+def _is_item_identifier(value: str) -> bool:
+    return bool(value) and bool(_ITEM_IDENTIFIER_PATTERN.fullmatch(value))
+
+
+def resolve_item_identifier(
+    vault: str, item: str, catalog: Optional[List[OnePasswordItem]] = None
+) -> Optional[str]:
+    """Return the stable identifier for ``item`` within ``vault`` when possible."""
+
+    candidate = (item or "").strip()
+    if _is_item_identifier(candidate):
+        return candidate
+
+    normalised_vault = (vault or "").strip().lower()
+    items = catalog if catalog is not None else list_items()
+    matches: List[OnePasswordItem] = []
+    for entry in items:
+        if normalised_vault and entry.vault.strip().lower() != normalised_vault:
+            continue
+        if entry.title.strip().lower() == candidate.lower():
+            matches.append(entry)
+
+    if not matches:
+        return None
+
+    if len(matches) == 1:
+        identifier = matches[0].identifier.strip()
+        return identifier or None
+
+    exact_case = [match for match in matches if match.title.strip() == candidate]
+    if len(exact_case) == 1:
+        identifier = exact_case[0].identifier.strip()
+        return identifier or None
+
+    favourites = [match for match in matches if match.favorite and match.identifier.strip()]
+    if len(favourites) == 1:
+        return favourites[0].identifier.strip()
+
+    raise MultipleItemsFoundError(vault, item, matches)
 
 
 def _item_reference(vault: str, item: str) -> str:
@@ -101,7 +161,30 @@ def get_item(
     """Return the raw JSON payload for a 1Password item."""
 
     reference = _item_reference(vault, item)
-    command_parts = ["op item get", *_item_command_args(vault, item), "--format", "json"]
+    try:
+        resolved_item = resolve_item_identifier(vault, item)
+    except MultipleItemsFoundError as exc:
+        print(
+            "Failed to resolve a unique 1Password item for "
+            f"{reference}. Multiple items matched the provided name."
+        )
+        for match in exc.matches:
+            print(f"  - {match.label()} [{match.identifier}]")
+        print("Please update the configuration to reference the desired item by ID.")
+        return None
+    if resolved_item is None and item:
+        print(
+            "Failed to locate 1Password item "
+            f"{reference}. Please verify the vault and item names."
+        )
+        return None
+
+    command_parts = [
+        "op item get",
+        *_item_command_args(vault, resolved_item or item),
+        "--format",
+        "json",
+    ]
     result = run(" ".join(command_parts))
     if result.returncode != 0:
         message = result.stderr.strip() or result.stdout.strip() or "unknown error"
@@ -161,6 +244,26 @@ def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]
     pitfalls when invoking the CLI.
     """
 
+    try:
+        resolved_item = resolve_item_identifier(vault, item)
+    except MultipleItemsFoundError as exc:
+        reference = _item_reference(vault, item)
+        print(
+            "Failed to resolve a unique 1Password item for "
+            f"{reference}. Multiple items matched the provided name."
+        )
+        for match in exc.matches:
+            print(f"  - {match.label()} [{match.identifier}]")
+        print("Please update the configuration to reference the desired item by ID.")
+        return False
+    if resolved_item is None:
+        reference = _item_reference(vault, item)
+        print(
+            "Failed to locate 1Password item "
+            f"{reference}. Please verify the vault and item names."
+        )
+        return False
+
     field_entries = []
     ensured_sections: set[str] = set()
     temp_files: List[Path] = []
@@ -187,7 +290,10 @@ def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]
             shlex.quote(f"{field_identifier}[value]=@{path.as_posix()}"))
 
     reference = _item_reference(vault, item)
-    command_parts = ["op item edit", *_item_command_args(vault, item)] + field_entries
+    command_parts = [
+        "op item edit",
+        *_item_command_args(vault, resolved_item),
+    ] + field_entries
     command = " ".join(command_parts)
     result = run(command)
 

--- a/utils/one_password.py
+++ b/utils/one_password.py
@@ -24,6 +24,7 @@ class OnePasswordItem:
     vault: str
     identifier: str
     favorite: bool = False
+    vault_id: str = ""
 
     def label(self) -> str:
         """Return a human-friendly label describing the item."""
@@ -70,14 +71,19 @@ def list_items() -> List[OnePasswordItem]:
     for entry in payload:
         vault_info = entry.get("vault") or {}
         vault_name = ""
+        vault_id = ""
         if isinstance(vault_info, dict):
-            vault_name = vault_info.get("name") or vault_info.get("id") or ""
+            vault_name = vault_info.get("name") or ""
+            vault_id = vault_info.get("id") or ""
+            if not vault_name:
+                vault_name = vault_id
         items.append(
             OnePasswordItem(
                 title=entry.get("title", ""),
                 vault=vault_name,
                 identifier=entry.get("id", ""),
                 favorite=bool(entry.get("favorite", False)),
+                vault_id=vault_id,
             )
         )
 
@@ -117,8 +123,17 @@ def resolve_item_identifier(
     items = catalog if catalog is not None else list_items()
     matches: List[OnePasswordItem] = []
     for entry in items:
-        if normalised_vault and entry.vault.strip().lower() != normalised_vault:
-            continue
+        if normalised_vault:
+            vault_aliases = {
+                alias.strip().lower()
+                for alias in (entry.vault, entry.vault_id)
+                if alias
+            }
+            if vault_aliases:
+                if normalised_vault not in vault_aliases:
+                    continue
+            elif entry.vault.strip().lower() != normalised_vault:
+                continue
         if entry.title.strip().lower() == candidate.lower():
             matches.append(entry)
 

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -14,6 +14,7 @@ from .accounts import GitAccount, get_account_config, save_account_config
 from .debian import run
 from .meta import KNOWN_HOSTS, SSH_CONFIG, SSH_DIR
 from .one_password import (
+    MultipleItemsFoundError,
     OnePasswordField,
     OnePasswordItem,
     ensure_op_connected,
@@ -21,6 +22,7 @@ from .one_password import (
     get_field_value,
     get_item,
     list_items,
+    resolve_item_identifier,
     update_item_fields,
 )
 
@@ -254,7 +256,7 @@ def _score_item(account: GitAccount, item: OnePasswordItem) -> int:
     return score
 
 
-def _prompt_for_item(account, catalog: List[OnePasswordItem]) -> Optional[Tuple[str, str]]:
+def _prompt_for_item(account, catalog: List[OnePasswordItem]) -> Optional[OnePasswordItem]:
     """Prompt the user to associate a 1Password item with an account."""
 
     if not catalog:
@@ -299,17 +301,17 @@ def _prompt_for_item(account, catalog: List[OnePasswordItem]) -> Optional[Tuple[
             continue
         if answer in option_map:
             selected = option_map[answer]
-            return selected.vault, selected.title
+            return selected
 
         print("Please choose a valid option.")
 
 
 def _auto_assign_items(
     accounts: List[GitAccount], catalog: List[OnePasswordItem]
-) -> Dict[str, Tuple[str, str]]:
+) -> Dict[str, OnePasswordItem]:
     """Return automatic vault/item assignments keyed by account slug."""
 
-    assignments: Dict[str, Tuple[str, str]] = {}
+    assignments: Dict[str, OnePasswordItem] = {}
     for account in accounts:
         ranked = sorted(
             catalog,
@@ -325,7 +327,7 @@ def _auto_assign_items(
         second_score = _score_item(account, ranked[1]) if len(ranked) > 1 else None
         unique_high = second_score is None or best_score >= (second_score + 2)
         if best_score >= 5 or unique_high:
-            assignments[account.slug] = (best.vault, best.title)
+            assignments[account.slug] = best
     return assignments
 
 
@@ -426,8 +428,63 @@ def configure_ssh():
     needs_mapping = [
         account for account in config.accounts if not account.op_vault or not account.op_item
     ]
+
+    catalog: List[OnePasswordItem] = []
+    updated_config = False
+
     if accounts_with_items or needs_mapping:
         ensure_op_connected()
+
+    if accounts_with_items:
+        catalog = list_items()
+        for account in list(accounts_with_items):
+            try:
+                resolved = resolve_item_identifier(
+                    account.op_vault or "", account.op_item or "", catalog
+                )
+            except MultipleItemsFoundError as exc:
+                reference = f"{account.op_vault}/{account.op_item}".strip("/")
+                print(
+                    "Multiple 1Password items match "
+                    f"'{reference or account.display_name}' for {account.display_name}."
+                )
+                if interactive and exc.matches:
+                    selection = _prompt_for_item(account, list(exc.matches))
+                    if selection:
+                        account.op_vault = selection.vault
+                        account.op_item = selection.identifier
+                        updated_config = True
+                        continue
+                account.op_item = None
+                updated_config = True
+                continue
+
+            if resolved and resolved != account.op_item:
+                account.op_item = resolved
+                updated_config = True
+            elif resolved is None:
+                reference = f"{account.op_vault}/{account.op_item}".strip("/")
+                print(
+                    "Unable to find 1Password item "
+                    f"'{reference or account.display_name}' for {account.display_name}."
+                )
+                if interactive and catalog:
+                    selection = _prompt_for_item(account, catalog)
+                    if selection:
+                        account.op_vault = selection.vault
+                        account.op_item = selection.identifier
+                        updated_config = True
+                        continue
+                account.op_item = None
+                updated_config = True
+
+    accounts_with_items = [
+        account for account in config.accounts if account.op_vault and account.op_item
+    ]
+    needs_mapping = [
+        account for account in config.accounts if not account.op_vault or not account.op_item
+    ]
+
     provisioned: List[Tuple[GitAccount, SshMaterial]] = []
     for account in accounts_with_items:
         material = _provision_ssh_material(account)
@@ -436,20 +493,19 @@ def configure_ssh():
     existing_config = SSH_CONFIG.read_text() if SSH_CONFIG.exists() else ""
     SSH_DIR.mkdir(parents=True, exist_ok=True)
 
-    catalog: List[OnePasswordItem] = []
-
-    updated_config = False
     if needs_mapping:
-        catalog = list_items()
+        if not catalog:
+            catalog = list_items()
         auto_assignments = _auto_assign_items(needs_mapping, catalog)
         for account in needs_mapping:
             if account.slug in auto_assignments:
-                vault, item = auto_assignments[account.slug]
-                account.op_vault, account.op_item = vault, item
+                selection = auto_assignments[account.slug]
+                account.op_vault = selection.vault
+                account.op_item = selection.identifier
                 updated_config = True
                 print(
                     f"Automatically mapped {account.display_name} ({account.provider})"
-                    f" -> {vault}/{item}"
+                    f" -> {selection.vault}/{selection.title}"
                 )
         needs_mapping = [
             account
@@ -461,7 +517,8 @@ def configure_ssh():
         for account in needs_mapping:
             selection = _prompt_for_item(account, catalog)
             if selection:
-                account.op_vault, account.op_item = selection
+                account.op_vault = selection.vault
+                account.op_item = selection.identifier
                 updated_config = True
     elif needs_mapping:
         print(
@@ -493,7 +550,8 @@ def configure_ssh():
             selection = _prompt_for_item(account, catalog)
             if not selection:
                 continue
-            account.op_vault, account.op_item = selection
+            account.op_vault = selection.vault
+            account.op_item = selection.identifier
             updated_config = True
             success, error = _install_keys_for_account(account)
             if success:


### PR DESCRIPTION
## Summary
- include 1Password item identifiers in our catalog and resolve stored item references to stable IDs, raising helpful errors when multiple matches are found
- normalise git account mappings to prefer item IDs, updating auto-assignment and interactive prompts to persist the correct selection

## Testing
- uv run python -m compileall utils

------
https://chatgpt.com/codex/tasks/task_e_6907109f2ea0832e88625d99560315fd