### PR TITLE
Fix 1Password CLI field update syntax

### DIFF
--- a/tests/test_one_password.py
+++ b/tests/test_one_password.py
@@ -1,0 +1,67 @@
+import os
+import sys
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utils import one_password
+
+
+def _mkstemp_factory(tmp_path):
+    counter = {"value": 0}
+
+    def fake_mkstemp(prefix: str):
+        index = counter["value"]
+        counter["value"] += 1
+        path = tmp_path / f"{prefix}{index}"
+        fd = os.open(path, os.O_RDWR | os.O_CREAT | os.O_TRUNC, 0o600)
+        return fd, path.as_posix()
+
+    return fake_mkstemp
+
+
+@pytest.mark.parametrize(
+    "concealed",
+    [False, True],
+)
+def test_update_item_fields_uses_supported_cli_syntax(tmp_path, monkeypatch, concealed):
+    monkeypatch.setattr(
+        one_password, "resolve_item_identifier", lambda vault, item, catalog=None: "item-id"
+    )
+
+    commands: list[str] = []
+
+    def fake_run(command: str):
+        commands.append(command)
+        return CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(one_password, "run", fake_run)
+    monkeypatch.setattr(one_password.tempfile, "mkstemp", _mkstemp_factory(tmp_path))
+
+    field = one_password.OnePasswordField(
+        section="ssh",
+        label="private" if concealed else "public",
+        value="example-value",
+        concealed=concealed,
+    )
+
+    assert one_password.update_item_fields("Vault", "Item", [field]) is True
+    assert len(commands) == 1
+
+    command = commands[0]
+    expected_path = (tmp_path / f"freckles-op-{0}").as_posix()
+
+    assert command.startswith("op item edit --vault Vault item-id")
+    assert "[label]" not in command
+    assert "[value]" not in command
+    assert "[type]" not in command
+
+    if concealed:
+        assert f"ssh.private[concealed]=@{expected_path}" in command
+    else:
+        assert f"ssh.public=@{expected_path}" in command

--- a/utils/one_password.py
+++ b/utils/one_password.py
@@ -280,7 +280,6 @@ def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]
         return False
 
     field_entries = []
-    ensured_sections: set[str] = set()
     temp_files: List[Path] = []
     for field in fields:
         fd, temp_path = tempfile.mkstemp(prefix="freckles-op-")
@@ -288,21 +287,11 @@ def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]
         path = Path(temp_path)
         temp_files.append(path)
         path.write_text(field.value)
-        section_prefix = ""
-        if field.section:
-            section_prefix = f"{field.section}."
-            if field.section not in ensured_sections:
-                ensured_sections.add(field.section)
-                field_entries.append(
-                    shlex.quote(f"{field.section}[label]={field.section}")
-                )
-
+        section_prefix = f"{field.section}." if field.section else ""
         field_identifier = f"{section_prefix}{field.label}"
-        field_entries.append(shlex.quote(f"{field_identifier}[label]={field.label}"))
-        if field.concealed:
-            field_entries.append(shlex.quote(f"{field_identifier}[type]=concealed"))
+        type_suffix = "[concealed]" if field.concealed else ""
         field_entries.append(
-            shlex.quote(f"{field_identifier}[value]=@{path.as_posix()}"))
+            shlex.quote(f"{field_identifier}{type_suffix}=@{path.as_posix()}"))
 
     reference = _item_reference(vault, item)
     command_parts = [


### PR DESCRIPTION
## Summary
- update 1Password field editing to emit supported `op item edit` arguments without label/type fragments
- rely on the CLI to manage section creation when initialising SSH placeholder fields
- add regression tests that exercise the generated command syntax for concealed and regular fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6907169fe514832e8a209dff8fb5b8df