### PR TITLE
Specify 1Password field types for text updates

### DIFF
--- a/tests/test_one_password.py
+++ b/tests/test_one_password.py
@@ -64,7 +64,7 @@ def test_update_item_fields_uses_supported_cli_syntax(tmp_path, monkeypatch, con
     if concealed:
         assert f"ssh.private[concealed]=@{expected_path}" in command
     else:
-        assert f"ssh.public=@{expected_path}" in command
+        assert f"ssh.public[text]=@{expected_path}" in command
 
 
 def test_update_item_fields_handles_cli_panic(tmp_path, monkeypatch, capsys):

--- a/utils/one_password.py
+++ b/utils/one_password.py
@@ -42,6 +42,7 @@ class OnePasswordField:
     value: str
     section: Optional[str] = None
     concealed: bool = False
+    kind: Optional[str] = "text"
 
 
 def ensure_op_connected() -> None:
@@ -291,7 +292,12 @@ def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]
         path.write_text(field.value)
         section_prefix = f"{field.section}." if field.section else ""
         field_identifier = f"{section_prefix}{field.label}"
-        type_suffix = "[concealed]" if field.concealed else ""
+        if field.concealed:
+            type_suffix = "[concealed]"
+        elif field.kind:
+            type_suffix = f"[{field.kind}]"
+        else:
+            type_suffix = ""
         field_entry = shlex.quote(
             f"{field_identifier}{type_suffix}=@{path.as_posix()}"
         )


### PR DESCRIPTION
## Summary
- default OnePasswordField entries to use the text type when editing items
- propagate the type information so op item edit sends an explicit `[text]` suffix
- adjust tests to capture the new CLI syntax

## Testing
- pytest tests/test_one_password.py

------
https://chatgpt.com/codex/tasks/task_e_6907252cc204832e84ead59a762602ac