### PR TITLE
Handle 1Password CLI crashes and validate SSH key fetches

### DIFF
--- a/tests/test_one_password.py
+++ b/tests/test_one_password.py
@@ -65,3 +65,35 @@ def test_update_item_fields_uses_supported_cli_syntax(tmp_path, monkeypatch, con
         assert f"ssh.private[concealed]=@{expected_path}" in command
     else:
         assert f"ssh.public=@{expected_path}" in command
+
+
+def test_update_item_fields_handles_cli_panic(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(
+        one_password, "resolve_item_identifier", lambda vault, item, catalog=None: "item-id"
+    )
+
+    commands: list[str] = []
+
+    def fake_run(command: str):
+        commands.append(command)
+        return CompletedProcess(
+            args=command,
+            returncode=1,
+            stdout="",
+            stderr="panic: runtime error: invalid memory address or nil pointer dereference",
+        )
+
+    monkeypatch.setattr(one_password, "run", fake_run)
+    monkeypatch.setattr(one_password.tempfile, "mkstemp", _mkstemp_factory(tmp_path))
+
+    field = one_password.OnePasswordField(
+        section="ssh",
+        label="public",
+        value="example-value",
+    )
+
+    assert one_password.update_item_fields("Vault", "Item", [field]) is False
+    assert len(commands) == 1
+
+    output = capsys.readouterr().out
+    assert "The 1Password CLI encountered an unexpected crash" in output

--- a/utils/one_password.py
+++ b/utils/one_password.py
@@ -259,6 +259,10 @@ def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]
     pitfalls when invoking the CLI.
     """
 
+    field_list = list(fields)
+    if not field_list:
+        return True
+
     try:
         resolved_item = resolve_item_identifier(vault, item)
     except MultipleItemsFoundError as exc:
@@ -279,38 +283,46 @@ def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]
         )
         return False
 
-    field_entries = []
-    temp_files: List[Path] = []
-    for field in fields:
+    reference = _item_reference(vault, item)
+    for field in field_list:
         fd, temp_path = tempfile.mkstemp(prefix="freckles-op-")
         os.close(fd)
         path = Path(temp_path)
-        temp_files.append(path)
         path.write_text(field.value)
         section_prefix = f"{field.section}." if field.section else ""
         field_identifier = f"{section_prefix}{field.label}"
         type_suffix = "[concealed]" if field.concealed else ""
-        field_entries.append(
-            shlex.quote(f"{field_identifier}{type_suffix}=@{path.as_posix()}"))
+        field_entry = shlex.quote(
+            f"{field_identifier}{type_suffix}=@{path.as_posix()}"
+        )
 
-    reference = _item_reference(vault, item)
-    command_parts = [
-        "op item edit",
-        *_item_command_args(vault, resolved_item),
-    ] + field_entries
-    command = " ".join(command_parts)
-    result = run(command)
+        command_parts = [
+            "op item edit",
+            *_item_command_args(vault, resolved_item),
+            field_entry,
+        ]
+        command = " ".join(command_parts)
+        result = run(command)
 
-    for path in temp_files:
         try:
             os.unlink(path)
         except OSError:
             pass
 
-    if result.returncode != 0:
-        message = result.stderr.strip() or result.stdout.strip() or "unknown error"
-        print(f"Failed to update 1Password item {reference}: {message}")
-        return False
+        if result.returncode != 0:
+            message = (
+                result.stderr.strip() or result.stdout.strip() or "unknown error"
+            )
+            print(f"Failed to update 1Password item {reference}: {message}")
+            normalized = message.lower()
+            if "panic" in normalized or "sigsegv" in normalized or "segmentation" in normalized:
+                print(
+                    "The 1Password CLI encountered an unexpected crash while editing "
+                    f"{reference}. Ensure the desktop app and CLI are up to date, "
+                    "then retry the operation. If the issue persists, update the "
+                    "fields manually in 1Password."
+                )
+            return False
 
     return True
 

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -404,6 +404,37 @@ def _install_keys_for_account(account) -> Tuple[bool, Optional[str]]:
         )
 
     try:
+        public_text = public_key.read_text()
+    except FileNotFoundError:
+        public_text = ""
+    try:
+        private_text = key_path.read_text()
+    except FileNotFoundError:
+        private_text = ""
+
+    if not public_text.strip() or "ssh-" not in public_text:
+        for path in (key_path, public_key):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+        return False, (
+            f"The 1Password item {account.op_vault}/{account.op_item} does not contain "
+            "an SSH public key. Please update the item manually and rerun the command."
+        )
+
+    if "PRIVATE KEY" not in private_text:
+        for path in (key_path, public_key):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+        return False, (
+            f"The 1Password item {account.op_vault}/{account.op_item} does not contain "
+            "an SSH private key. Please update the item manually and rerun the command."
+        )
+
+    try:
         private_key_path = key_path
         private_key_path.chmod(0o600)
         public_key.chmod(0o644)


### PR DESCRIPTION
## Summary
- retry 1Password field updates per field and surface actionable guidance when the CLI crashes
- detect missing SSH key material read from 1Password and stop before adding empty keys to the agent
- add regression coverage around the CLI panic handling logic in update_item_fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690718f84e18832eb1603bb6f9b1e0b8