### PR TITLE
Avoid overwriting existing 1Password key material

### DIFF
--- a/utils/gpg.py
+++ b/utils/gpg.py
@@ -152,7 +152,9 @@ def _needs_update(item: Optional[Dict], field: str) -> bool:
     if not item:
         return True
     value = get_field_value(item, "gpg", field)
-    return not value
+    if value is None:
+        return True
+    return not str(value).strip()
 
 
 def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgMaterial]]:
@@ -214,7 +216,7 @@ def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgM
                     concealed=True,
                 )
             )
-        if _needs_update(item, "key_id") or (item and get_field_value(item, "gpg", "key_id") != key_id):
+        if _needs_update(item, "key_id"):
             fields.append(
                 OnePasswordField(
                     section="gpg",
@@ -222,10 +224,7 @@ def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgM
                     value=key_id,
                 )
             )
-        if fingerprint and (
-            _needs_update(item, "fingerprint")
-            or (item and get_field_value(item, "gpg", "fingerprint") != fingerprint)
-        ):
+        if fingerprint and _needs_update(item, "fingerprint"):
             fields.append(
                 OnePasswordField(
                     section="gpg",

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -167,31 +167,56 @@ def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
         fingerprint = remote_fingerprint.strip()
 
     fields: List[OnePasswordField] = []
-    if not remote_public.strip():
-        fields.append(
-            OnePasswordField(
-                section="ssh",
-                label="public",
-                value=local_public + "\n",
-            )
+    if created:
+        fields.extend(
+            [
+                OnePasswordField(
+                    section="ssh",
+                    label="public",
+                    value=local_public + "\n",
+                ),
+                OnePasswordField(
+                    section="ssh",
+                    label="private",
+                    value=local_private + "\n",
+                    concealed=True,
+                ),
+            ]
         )
-    if not remote_private.strip():
-        fields.append(
-            OnePasswordField(
-                section="ssh",
-                label="private",
-                value=local_private + "\n",
-                concealed=True,
+        if fingerprint:
+            fields.append(
+                OnePasswordField(
+                    section="ssh",
+                    label="fingerprint",
+                    value=fingerprint,
+                )
             )
-        )
-    if fingerprint and not remote_fingerprint.strip():
-        fields.append(
-            OnePasswordField(
-                section="ssh",
-                label="fingerprint",
-                value=fingerprint,
+    else:
+        if not remote_public.strip():
+            fields.append(
+                OnePasswordField(
+                    section="ssh",
+                    label="public",
+                    value=local_public + "\n",
+                )
             )
-        )
+        if not remote_private.strip():
+            fields.append(
+                OnePasswordField(
+                    section="ssh",
+                    label="private",
+                    value=local_private + "\n",
+                    concealed=True,
+                )
+            )
+        if fingerprint and not remote_fingerprint.strip():
+            fields.append(
+                OnePasswordField(
+                    section="ssh",
+                    label="fingerprint",
+                    value=fingerprint,
+                )
+            )
 
     missing_item = item is None
     prepared = ensure_ssh_container(

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -167,7 +167,7 @@ def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
         fingerprint = remote_fingerprint.strip()
 
     fields: List[OnePasswordField] = []
-    if not remote_public.strip() or remote_public.strip() != local_public:
+    if not remote_public.strip():
         fields.append(
             OnePasswordField(
                 section="ssh",
@@ -175,7 +175,7 @@ def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
                 value=local_public + "\n",
             )
         )
-    if not remote_private.strip() or remote_private.strip() != local_private:
+    if not remote_private.strip():
         fields.append(
             OnePasswordField(
                 section="ssh",
@@ -184,7 +184,7 @@ def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
                 concealed=True,
             )
         )
-    if fingerprint and (not remote_fingerprint.strip() or remote_fingerprint.strip() != fingerprint):
+    if fingerprint and not remote_fingerprint.strip():
         fields.append(
             OnePasswordField(
                 section="ssh",


### PR DESCRIPTION
## Summary
- stop writing SSH key fields back to 1Password when material is already present
- avoid updating existing GPG fields to prevent 1Password validation errors

## Testing
- pytest tests/test_one_password.py

------
https://chatgpt.com/codex/tasks/task_e_69071b6bd388832e88ed1697a264fb63