### PR TITLE
Handle placeholder GPG material values from 1Password

### DIFF
--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -1,0 +1,147 @@
+import sys
+from subprocess import CompletedProcess
+
+import pytest
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utils import gpg  # noqa: E402
+from utils.accounts import AccountConfig, GitAccount  # noqa: E402
+
+
+def _build_account():
+    account = GitAccount(
+        scope="work",
+        provider="github",
+        display_name="Example User",
+        email="example@example.com",
+        directory="~/work/example",
+        op_vault="Vault",
+        op_item="Item",
+    )
+    return account
+
+
+def _placeholder_item():
+    return {
+        "fields": [
+            {
+                "label": "public",
+                "section": {"label": "gpg"},
+                "value": "@/tmp/freckles-op-placeholder",
+            },
+            {
+                "label": "private",
+                "section": {"label": "gpg"},
+                "value": "@/tmp/freckles-op-placeholder",
+            },
+            {
+                "label": "key_id",
+                "section": {"label": "gpg"},
+                "value": "",
+            },
+            {
+                "label": "fingerprint",
+                "section": {"label": "gpg"},
+                "value": "",
+            },
+        ]
+    }
+
+
+def test_import_remote_key_ignores_placeholder(monkeypatch):
+    account = _build_account()
+    commands = []
+
+    def fake_run(command: str):
+        commands.append(command)
+        return CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gpg, "run", fake_run)
+
+    assert gpg._import_remote_key(account, _placeholder_item()) is None
+    assert commands == []
+
+
+def test_provision_replaces_placeholder_fields(monkeypatch):
+    account = _build_account()
+    config = AccountConfig(accounts=[account], default_account=account.slug)
+
+    key_id = "ABCDEF1234567890"
+    fingerprint = "FINGERPRINT1234567890"
+
+    item_payload = _placeholder_item()
+
+    def fake_get_item(vault: str, item: str, suppress_missing: bool = False):
+        assert vault == "Vault"
+        assert item == "Item"
+        return item_payload
+
+    updated_fields = []
+
+    def fake_update_item_fields(vault: str, item: str, fields):
+        updated_fields.extend(fields)
+        return True
+
+    saved_configs = []
+
+    def fake_save_account_config(value):
+        saved_configs.append(value)
+
+    commands = []
+
+    def fake_run(command: str):
+        commands.append(command)
+        if "--generate-key" in command:
+            pytest.fail("Unexpected request to generate a new GPG key")
+        if command.startswith("gpg --list-secret-keys"):
+            payload = (
+                "sec:u:4096:1:ABCDEF1234567890:0:0:::\n"
+                "fpr:::::::::FINGERPRINT1234567890:\n"
+            )
+            return CompletedProcess(args=command, returncode=0, stdout=payload, stderr="")
+        if command.startswith("gpg --armor --export-secret-keys"):
+            return CompletedProcess(args=command, returncode=0, stdout="PRIVATE-KEY\n", stderr="")
+        if command.startswith("gpg --armor --export"):
+            return CompletedProcess(args=command, returncode=0, stdout="PUBLIC-KEY\n", stderr="")
+        if command.startswith("gpg --with-colons --fingerprint"):
+            payload = (
+                "sec:u:4096:1:ABCDEF1234567890:0:0:::\n"
+                "fpr:::::::::FINGERPRINT1234567890:\n"
+            )
+            return CompletedProcess(args=command, returncode=0, stdout=payload, stderr="")
+        return CompletedProcess(args=command, returncode=1, stdout="", stderr="unexpected command")
+
+    monkeypatch.setattr(gpg, "run", fake_run)
+    monkeypatch.setattr(gpg, "ensure_op_connected", lambda: None)
+    monkeypatch.setattr(gpg, "get_item", fake_get_item)
+    monkeypatch.setattr(gpg, "update_item_fields", fake_update_item_fields)
+    monkeypatch.setattr(gpg, "save_account_config", fake_save_account_config)
+
+    updates = gpg.provision_gpg_material(config)
+
+    assert len(updates) == 1
+    updated_account, material = updates[0]
+    assert updated_account is account
+    assert material.key_id == key_id
+    assert material.fingerprint == fingerprint
+    assert material.public_key == "PUBLIC-KEY"
+    assert material.private_key == "PRIVATE-KEY"
+
+    assert saved_configs and saved_configs[0] is config
+
+    assert {field.label for field in updated_fields} == {
+        "public",
+        "private",
+        "key_id",
+        "fingerprint",
+    }
+    for field in updated_fields:
+        assert not field.value.strip().startswith("@")
+
+    assert any(cmd.startswith("gpg --armor --export ") for cmd in commands)
+    assert any(cmd.startswith("gpg --armor --export-secret-keys ") for cmd in commands)

--- a/utils/gpg.py
+++ b/utils/gpg.py
@@ -8,6 +8,28 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+
+def _has_material_value(value: Optional[str]) -> bool:
+    """Return ``True`` when ``value`` appears to contain actual key material."""
+
+    if value is None:
+        return False
+
+    stripped = value.strip()
+    if not stripped:
+        return False
+
+    if stripped.startswith("@"):
+        remainder = stripped[1:]
+        if not remainder:
+            return False
+        if remainder.startswith(("/", "\\", "~")):
+            return False
+        if len(remainder) >= 2 and remainder[1] == ":" and remainder[0].isalpha():
+            return False
+
+    return True
+
 from .accounts import AccountConfig, GitAccount, save_account_config
 from .debian import run
 from .one_password import (
@@ -64,7 +86,7 @@ def _import_remote_key(account: GitAccount, item: Optional[Dict]) -> Optional[Tu
         return None
 
     private_key = get_field_value(item, "gpg", "private") or ""
-    if not private_key.strip():
+    if not _has_material_value(private_key):
         return None
 
     with tempfile.NamedTemporaryFile("w", delete=False) as handle:
@@ -152,9 +174,7 @@ def _needs_update(item: Optional[Dict], field: str) -> bool:
     if not item:
         return True
     value = get_field_value(item, "gpg", field)
-    if value is None:
-        return True
-    return not str(value).strip()
+    return not _has_material_value(value)
 
 
 def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgMaterial]]:
@@ -176,10 +196,12 @@ def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgM
         item = get_item(account.op_vault, account.op_item, suppress_missing=True)
         remote_public = (get_field_value(item, "gpg", "public") or "") if item else ""
         remote_private = (get_field_value(item, "gpg", "private") or "") if item else ""
-        remote_has_material = bool(remote_public.strip() and remote_private.strip())
+        remote_has_material = _has_material_value(remote_public) and _has_material_value(
+            remote_private
+        )
         details = _discover_existing_key(account)
         generated_new_key = False
-        if details is None and remote_private.strip():
+        if details is None and _has_material_value(remote_private):
             details = _import_remote_key(account, item)
             if details is None:
                 continue

--- a/utils/gpg.py
+++ b/utils/gpg.py
@@ -170,11 +170,17 @@ def _export_material(key_id: str) -> Optional[GpgMaterial]:
     )
 
 
-def _needs_update(item: Optional[Dict], field: str) -> bool:
+def _needs_update(
+    item: Optional[Dict], field: str, *, expected: Optional[str] = None
+) -> bool:
     if not item:
         return True
     value = get_field_value(item, "gpg", field)
-    return not _has_material_value(value)
+    if not _has_material_value(value):
+        return True
+    if expected is None:
+        return False
+    return (value or "").strip() != expected.strip()
 
 
 def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgMaterial]]:
@@ -225,8 +231,8 @@ def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgM
             signing_changed = True
 
         fields: List[OnePasswordField] = []
-        if not remote_has_material and material is not None:
-            if _needs_update(item, "public"):
+        if material is not None:
+            if _needs_update(item, "public", expected=material.public_key):
                 fields.append(
                     OnePasswordField(
                         section="gpg",
@@ -234,7 +240,7 @@ def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgM
                         value=material.public_key + "\n",
                     )
                 )
-            if _needs_update(item, "private"):
+            if _needs_update(item, "private", expected=material.private_key):
                 fields.append(
                     OnePasswordField(
                         section="gpg",
@@ -243,22 +249,22 @@ def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgM
                         concealed=True,
                     )
                 )
-            if _needs_update(item, "key_id"):
-                fields.append(
-                    OnePasswordField(
-                        section="gpg",
-                        label="key_id",
-                        value=key_id,
-                    )
+        if _needs_update(item, "key_id", expected=key_id):
+            fields.append(
+                OnePasswordField(
+                    section="gpg",
+                    label="key_id",
+                    value=key_id,
                 )
-            if fingerprint and _needs_update(item, "fingerprint"):
-                fields.append(
-                    OnePasswordField(
-                        section="gpg",
-                        label="fingerprint",
-                        value=fingerprint,
-                    )
+            )
+        if fingerprint and _needs_update(item, "fingerprint", expected=fingerprint):
+            fields.append(
+                OnePasswordField(
+                    section="gpg",
+                    label="fingerprint",
+                    value=fingerprint,
                 )
+            )
 
         fields_updated = False
         if fields:


### PR DESCRIPTION
## Summary
- treat 1Password field values that look like op CLI placeholders as missing GPG material
- avoid importing placeholder values and update stored keys when placeholders are detected
- add regression tests exercising GPG provisioning with placeholder field data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690729ee3444832e9af20fa9c3e22296