### PR TITLE
Protect existing 1Password key material from regeneration

### DIFF
--- a/utils/gpg.py
+++ b/utils/gpg.py
@@ -6,7 +6,7 @@ import shlex
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 
 def _has_material_value(value: Optional[str]) -> bool:
@@ -29,6 +29,41 @@ def _has_material_value(value: Optional[str]) -> bool:
             return False
 
     return True
+
+
+def _looks_like_pgp_public_key(value: Optional[str]) -> bool:
+    """Return ``True`` when ``value`` resembles an exported PGP public key."""
+
+    if value is None:
+        return False
+
+    text = value.strip()
+    if not text:
+        return False
+
+    begin = "-----BEGIN PGP PUBLIC KEY BLOCK-----"
+    end = "-----END PGP PUBLIC KEY BLOCK-----"
+    return text.startswith(begin) and end in text
+
+
+def _looks_like_pgp_private_key(value: Optional[str]) -> bool:
+    """Return ``True`` when ``value`` resembles an exported PGP private key."""
+
+    if value is None:
+        return False
+
+    text = value.strip()
+    if not text:
+        return False
+
+    private_markers = [
+        ("-----BEGIN PGP PRIVATE KEY BLOCK-----", "-----END PGP PRIVATE KEY BLOCK-----"),
+        ("-----BEGIN PGP SECRET KEY BLOCK-----", "-----END PGP SECRET KEY BLOCK-----"),
+    ]
+    for begin, end in private_markers:
+        if text.startswith(begin) and end in text:
+            return True
+    return False
 
 from .accounts import AccountConfig, GitAccount, save_account_config
 from .debian import run
@@ -86,7 +121,7 @@ def _import_remote_key(account: GitAccount, item: Optional[Dict]) -> Optional[Tu
         return None
 
     private_key = get_field_value(item, "gpg", "private") or ""
-    if not _has_material_value(private_key):
+    if not _looks_like_pgp_private_key(private_key):
         return None
 
     with tempfile.NamedTemporaryFile("w", delete=False) as handle:
@@ -171,11 +206,17 @@ def _export_material(key_id: str) -> Optional[GpgMaterial]:
 
 
 def _needs_update(
-    item: Optional[Dict], field: str, *, expected: Optional[str] = None
+    item: Optional[Dict],
+    field: str,
+    *,
+    expected: Optional[str] = None,
+    validator: Optional[Callable[[Optional[str]], bool]] = None,
 ) -> bool:
     if not item:
         return True
     value = get_field_value(item, "gpg", field)
+    if validator and validator(value):
+        return False
     if not _has_material_value(value):
         return True
     if expected is None:
@@ -202,15 +243,23 @@ def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgM
         item = get_item(account.op_vault, account.op_item, suppress_missing=True)
         remote_public = (get_field_value(item, "gpg", "public") or "") if item else ""
         remote_private = (get_field_value(item, "gpg", "private") or "") if item else ""
-        remote_has_material = _has_material_value(remote_public) and _has_material_value(
-            remote_private
-        )
+        remote_public_valid = _looks_like_pgp_public_key(remote_public)
+        remote_private_valid = _looks_like_pgp_private_key(remote_private)
+        remote_has_material = remote_public_valid and remote_private_valid
         details = _discover_existing_key(account)
         generated_new_key = False
-        if details is None and _has_material_value(remote_private):
+        if details is None and remote_private_valid:
             details = _import_remote_key(account, item)
             if details is None:
                 continue
+        if details is None and remote_public_valid and not remote_private_valid:
+            print(
+                "Skipping GPG provisioning for"
+                f" {account.display_name} ({account.email}) because the"
+                " 1Password item contains a GPG public key but the private key is"
+                " missing or malformed. Manual intervention is required."
+            )
+            continue
         if details is None:
             details = _generate_key(account)
             generated_new_key = details is not None
@@ -232,7 +281,12 @@ def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgM
 
         fields: List[OnePasswordField] = []
         if material is not None:
-            if _needs_update(item, "public", expected=material.public_key):
+            if _needs_update(
+                item,
+                "public",
+                expected=material.public_key,
+                validator=_looks_like_pgp_public_key,
+            ):
                 fields.append(
                     OnePasswordField(
                         section="gpg",
@@ -240,7 +294,12 @@ def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgM
                         value=material.public_key + "\n",
                     )
                 )
-            if _needs_update(item, "private", expected=material.private_key):
+            if _needs_update(
+                item,
+                "private",
+                expected=material.private_key,
+                validator=_looks_like_pgp_private_key,
+            ):
                 fields.append(
                     OnePasswordField(
                         section="gpg",

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -133,19 +133,44 @@ def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
     local_private = _read_text(key_path)
     local_public = _read_text(public_path)
 
-    remote_public = get_field_value(item, "ssh", "public") or ""
-    remote_private = get_field_value(item, "ssh", "private") or ""
+    remote_public_raw = get_field_value(item, "ssh", "public") or ""
+    remote_private_raw = get_field_value(item, "ssh", "private") or ""
     remote_fingerprint = get_field_value(item, "ssh", "fingerprint") or ""
 
-    if not local_public and remote_public:
-        local_public = remote_public.strip()
-    if not local_private and remote_private:
-        local_private = remote_private.strip()
+    remote_public_valid = _looks_like_public_key(remote_public_raw)
+    remote_private_valid = _looks_like_private_key(remote_private_raw)
+
+    remote_public = remote_public_raw.strip() if remote_public_valid else ""
+    remote_private = remote_private_raw.strip() if remote_private_valid else ""
+
+    if not local_public and remote_public_valid:
+        local_public = remote_public
+    if not local_private and remote_private_valid:
+        local_private = remote_private
+
+    derived_public: Optional[str] = None
+    if remote_private_valid and (not remote_public_valid or not local_public):
+        derived_public = _derive_public_from_private(remote_private)
+        if derived_public and not local_public:
+            local_public = derived_public.strip()
+
+    if remote_public_valid and not remote_private_valid and not local_private:
+        print(
+            "Skipping SSH provisioning for"
+            f" {account.display_name} ({account.provider}) because the"
+            " 1Password item contains an SSH public key but the private key is"
+            " missing or malformed. Manual intervention is required."
+        )
+        return None
 
     created = False
-    remote_has_material = bool(remote_public.strip() and remote_private.strip())
+    should_generate = (
+        not remote_public_valid
+        and not remote_private_valid
+        and (not local_public or not local_private)
+    )
 
-    if not remote_has_material and (not local_public or not local_private):
+    if should_generate:
         generated = _generate_local_key(account, key_path, public_path)
         if not generated:
             return None
@@ -167,57 +192,58 @@ def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
         fingerprint = remote_fingerprint.strip()
 
     fields: List[OnePasswordField] = []
-    if not remote_has_material:
-        if created:
-            fields.extend(
-                [
-                    OnePasswordField(
-                        section="ssh",
-                        label="public",
-                        value=local_public + "\n",
-                    ),
-                    OnePasswordField(
-                        section="ssh",
-                        label="private",
-                        value=local_private + "\n",
-                        concealed=True,
-                    ),
-                ]
+    if created:
+        fields.extend(
+            [
+                OnePasswordField(
+                    section="ssh",
+                    label="public",
+                    value=local_public + "\n",
+                ),
+                OnePasswordField(
+                    section="ssh",
+                    label="private",
+                    value=local_private + "\n",
+                    concealed=True,
+                ),
+            ]
+        )
+        if fingerprint:
+            fields.append(
+                OnePasswordField(
+                    section="ssh",
+                    label="fingerprint",
+                    value=fingerprint,
+                )
             )
-            if fingerprint:
-                fields.append(
-                    OnePasswordField(
-                        section="ssh",
-                        label="fingerprint",
-                        value=fingerprint,
-                    )
-                )
-        else:
-            if not remote_public.strip():
+    else:
+        if local_public and not remote_public_valid:
+            public_value = (derived_public or local_public).strip()
+            if public_value:
                 fields.append(
                     OnePasswordField(
                         section="ssh",
                         label="public",
-                        value=local_public + "\n",
+                        value=public_value + "\n",
                     )
                 )
-            if not remote_private.strip():
-                fields.append(
-                    OnePasswordField(
-                        section="ssh",
-                        label="private",
-                        value=local_private + "\n",
-                        concealed=True,
-                    )
+        if local_private and not remote_private_valid:
+            fields.append(
+                OnePasswordField(
+                    section="ssh",
+                    label="private",
+                    value=local_private + "\n",
+                    concealed=True,
+                ),
+            )
+        if fingerprint and not remote_fingerprint.strip():
+            fields.append(
+                OnePasswordField(
+                    section="ssh",
+                    label="fingerprint",
+                    value=fingerprint,
                 )
-            if fingerprint and not remote_fingerprint.strip():
-                fields.append(
-                    OnePasswordField(
-                        section="ssh",
-                        label="fingerprint",
-                        value=fingerprint,
-                    )
-                )
+            )
 
     missing_item = item is None
     prepared = ensure_ssh_container(
@@ -638,3 +664,70 @@ def configure_ssh():
             print(material.public_key)
             if material.fingerprint:
                 print(f"Fingerprint: {material.fingerprint}")
+
+
+def _looks_like_public_key(value: Optional[str]) -> bool:
+    """Return ``True`` when ``value`` resembles an SSH public key."""
+
+    if value is None:
+        return False
+
+    text = value.strip()
+    if not text:
+        return False
+
+    parts = text.split()
+    if len(parts) < 2:
+        return False
+
+    prefix = parts[0].lower()
+    valid_prefixes = (
+        "ssh-",
+        "ecdsa-",
+        "sk-",
+        "ecdsa-sk-",
+    )
+    return any(prefix.startswith(candidate) for candidate in valid_prefixes)
+
+
+def _looks_like_private_key(value: Optional[str]) -> bool:
+    """Return ``True`` when ``value`` resembles an SSH private key."""
+
+    if value is None:
+        return False
+
+    text = value.strip()
+    if not text:
+        return False
+
+    if "-----BEGIN" not in text or "PRIVATE KEY-----" not in text:
+        return False
+
+    return "-----END" in text and "PRIVATE KEY-----" in text.split("-----END")[-1]
+
+
+def _derive_public_from_private(private_key: str) -> Optional[str]:
+    """Return the public key derived from ``private_key`` when possible."""
+
+    if not private_key.strip():
+        return None
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as handle:
+        temp_path = Path(handle.name)
+        handle.write(private_key.strip() + "\n")
+
+    try:
+        result = run(
+            "ssh-keygen -y -f " + shlex.quote(temp_path.as_posix())
+        )
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        return None
+
+    output = (result.stdout or "").strip()
+    if not output:
+        return None
+    return output
+


### PR DESCRIPTION
## Summary
- add validation helpers that detect authentic PGP/SSH key blobs so existing vault material is left untouched
- warn and skip provisioning when a vault item only has a public key, and only generate fresh material when both halves are missing or malformed
- derive missing SSH publics from valid privates and update 1Password fields selectively so only malformed entries are replaced

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6907310487c4832e9e0b17489b50de02