### PR TITLE
Use JSON payloads for 1Password CLI edits

### DIFF
--- a/tests/test_one_password.py
+++ b/tests/test_one_password.py
@@ -1,4 +1,6 @@
+import json
 import os
+import shlex
 import sys
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -15,10 +17,10 @@ from utils import one_password
 def _mkstemp_factory(tmp_path):
     counter = {"value": 0}
 
-    def fake_mkstemp(prefix: str):
+    def fake_mkstemp(prefix: str, suffix: str = ""):
         index = counter["value"]
         counter["value"] += 1
-        path = tmp_path / f"{prefix}{index}"
+        path = tmp_path / f"{prefix}{index}{suffix}"
         fd = os.open(path, os.O_RDWR | os.O_CREAT | os.O_TRUNC, 0o600)
         return fd, path.as_posix()
 
@@ -35,9 +37,16 @@ def test_update_item_fields_uses_supported_cli_syntax(tmp_path, monkeypatch, con
     )
 
     commands: list[str] = []
+    payloads: list[str] = []
 
     def fake_run(command: str):
         commands.append(command)
+        tokens = shlex.split(command)
+        if "--input-file" in tokens:
+            index = tokens.index("--input-file")
+            if index + 1 < len(tokens):
+                payload_path = Path(tokens[index + 1])
+                payloads.append(payload_path.read_text())
         return CompletedProcess(args=command, returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(one_password, "run", fake_run)
@@ -54,17 +63,19 @@ def test_update_item_fields_uses_supported_cli_syntax(tmp_path, monkeypatch, con
     assert len(commands) == 1
 
     command = commands[0]
-    expected_path = (tmp_path / f"freckles-op-{0}").as_posix()
 
     assert command.startswith("op item edit --vault Vault item-id")
-    assert "[label]" not in command
-    assert "[value]" not in command
-    assert "[type]" not in command
+    assert "--input-file" in command
 
-    if concealed:
-        assert f"ssh.private[concealed]=@{expected_path}" in command
-    else:
-        assert f"ssh.public[text]=@{expected_path}" in command
+    assert payloads, "expected payload to be captured"
+    payload = json.loads(payloads[0])
+    assert "fields" in payload and len(payload["fields"]) == 1
+    field_payload = payload["fields"][0]
+    assert field_payload["label"] == ("private" if concealed else "public")
+    assert field_payload["value"] == "example-value"
+    assert "@" not in field_payload["value"]
+    assert field_payload["type"] == ("concealed" if concealed else "string")
+    assert field_payload.get("section", {}).get("id") == "ssh"
 
 
 def test_update_item_fields_handles_cli_panic(tmp_path, monkeypatch, capsys):
@@ -76,6 +87,12 @@ def test_update_item_fields_handles_cli_panic(tmp_path, monkeypatch, capsys):
 
     def fake_run(command: str):
         commands.append(command)
+        tokens = shlex.split(command)
+        if "--input-file" in tokens:
+            index = tokens.index("--input-file")
+            if index + 1 < len(tokens):
+                payload_path = Path(tokens[index + 1])
+                payload_path.read_text()
         return CompletedProcess(
             args=command,
             returncode=1,

--- a/utils/one_password.py
+++ b/utils/one_password.py
@@ -254,11 +254,7 @@ def get_field_value(item: Dict, section: Optional[str], label: str) -> Optional[
 
 
 def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]) -> bool:
-    """Update or create fields on a 1Password item.
-
-    Multi-line values are written to temporary files to avoid shell quoting
-    pitfalls when invoking the CLI.
-    """
+    """Update or create fields on a 1Password item."""
 
     field_list = list(fields)
     if not field_list:
@@ -284,51 +280,49 @@ def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]
         )
         return False
 
-    reference = _item_reference(vault, item)
+    payload_fields: List[Dict[str, object]] = []
     for field in field_list:
-        fd, temp_path = tempfile.mkstemp(prefix="freckles-op-")
-        os.close(fd)
-        path = Path(temp_path)
-        path.write_text(field.value)
-        section_prefix = f"{field.section}." if field.section else ""
-        field_identifier = f"{section_prefix}{field.label}"
-        if field.concealed:
-            type_suffix = "[concealed]"
-        elif field.kind:
-            type_suffix = f"[{field.kind}]"
-        else:
-            type_suffix = ""
-        field_entry = shlex.quote(
-            f"{field_identifier}{type_suffix}=@{path.as_posix()}"
-        )
+        entry: Dict[str, object] = {
+            "label": field.label,
+            "value": field.value,
+            "type": "concealed" if field.concealed else "string",
+        }
+        if field.section:
+            entry["section"] = {"id": field.section}
+        payload_fields.append(entry)
 
-        command_parts = [
-            "op item edit",
-            *_item_command_args(vault, resolved_item),
-            field_entry,
-        ]
-        command = " ".join(command_parts)
-        result = run(command)
+    fd, temp_path = tempfile.mkstemp(prefix="freckles-op-", suffix=".json")
+    os.close(fd)
+    path = Path(temp_path)
+    payload = {"fields": payload_fields}
+    path.write_text(json.dumps(payload))
 
-        try:
-            os.unlink(path)
-        except OSError:
-            pass
+    reference = _item_reference(vault, item)
+    command_parts = [
+        "op item edit",
+        *_item_command_args(vault, resolved_item),
+        f"--input-file {shlex.quote(path.as_posix())}",
+    ]
+    command = " ".join(command_parts)
+    result = run(command)
 
-        if result.returncode != 0:
-            message = (
-                result.stderr.strip() or result.stdout.strip() or "unknown error"
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        print(f"Failed to update 1Password item {reference}: {message}")
+        normalized = message.lower()
+        if "panic" in normalized or "sigsegv" in normalized or "segmentation" in normalized:
+            print(
+                "The 1Password CLI encountered an unexpected crash while editing "
+                f"{reference}. Ensure the desktop app and CLI are up to date, "
+                "then retry the operation. If the issue persists, update the "
+                "fields manually in 1Password."
             )
-            print(f"Failed to update 1Password item {reference}: {message}")
-            normalized = message.lower()
-            if "panic" in normalized or "sigsegv" in normalized or "segmentation" in normalized:
-                print(
-                    "The 1Password CLI encountered an unexpected crash while editing "
-                    f"{reference}. Ensure the desktop app and CLI are up to date, "
-                    "then retry the operation. If the issue persists, update the "
-                    "fields manually in 1Password."
-                )
-            return False
+        return False
 
     return True
 


### PR DESCRIPTION
## Summary
- send field updates to `op item edit` via a JSON payload so the CLI receives literal values
- keep SSH/GPG helpers compatible with the new helper shape
- extend the one_password tests to validate the payload contents and invocation path

## Testing
- pytest tests/test_one_password.py

------
https://chatgpt.com/codex/tasks/task_e_690737c7b198832ebb3f9981a2aed9e8