### PR TITLE
Fix 1Password CLI edit flag usage

### DIFF
--- a/tests/test_one_password.py
+++ b/tests/test_one_password.py
@@ -42,8 +42,8 @@ def test_update_item_fields_uses_supported_cli_syntax(tmp_path, monkeypatch, con
     def fake_run(command: str):
         commands.append(command)
         tokens = shlex.split(command)
-        if "--input-file" in tokens:
-            index = tokens.index("--input-file")
+        if "--template" in tokens:
+            index = tokens.index("--template")
             if index + 1 < len(tokens):
                 payload_path = Path(tokens[index + 1])
                 payloads.append(payload_path.read_text())
@@ -65,7 +65,7 @@ def test_update_item_fields_uses_supported_cli_syntax(tmp_path, monkeypatch, con
     command = commands[0]
 
     assert command.startswith("op item edit --vault Vault item-id")
-    assert "--input-file" in command
+    assert "--template" in command
 
     assert payloads, "expected payload to be captured"
     payload = json.loads(payloads[0])
@@ -88,8 +88,8 @@ def test_update_item_fields_handles_cli_panic(tmp_path, monkeypatch, capsys):
     def fake_run(command: str):
         commands.append(command)
         tokens = shlex.split(command)
-        if "--input-file" in tokens:
-            index = tokens.index("--input-file")
+        if "--template" in tokens:
+            index = tokens.index("--template")
             if index + 1 < len(tokens):
                 payload_path = Path(tokens[index + 1])
                 payload_path.read_text()

--- a/utils/one_password.py
+++ b/utils/one_password.py
@@ -301,7 +301,7 @@ def update_item_fields(vault: str, item: str, fields: Iterable[OnePasswordField]
     command_parts = [
         "op item edit",
         *_item_command_args(vault, resolved_item),
-        f"--input-file {shlex.quote(path.as_posix())}",
+        f"--template {shlex.quote(path.as_posix())}",
     ]
     command = " ".join(command_parts)
     result = run(command)


### PR DESCRIPTION
## Summary
- replace the deprecated `--input-file` flag with the new `--template` flag when editing items via the 1Password CLI
- update the associated tests to look for the new flag and continue validating payload contents

## Testing
- uv run pytest tests/test_one_password.py

------
https://chatgpt.com/codex/tasks/task_e_69073ae0ee4c832e8bc6b627cee322a2