### PR TITLE
Remove 1Password provisioning from git credentials

### DIFF
--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -1,8 +1,4 @@
 import sys
-from subprocess import CompletedProcess
-
-import pytest
-
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -10,138 +6,69 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils import gpg  # noqa: E402
-from utils.accounts import AccountConfig, GitAccount  # noqa: E402
 
 
-def _build_account():
-    account = GitAccount(
-        scope="work",
-        provider="github",
-        display_name="Example User",
-        email="example@example.com",
-        directory="~/work/example",
-        op_vault="Vault",
-        op_item="Item",
-    )
-    return account
+class FakeProcess:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
 
 
-def _placeholder_item():
-    return {
-        "fields": [
-            {
-                "label": "public",
-                "section": {"label": "gpg"},
-                "value": "@/tmp/freckles-op-placeholder",
-            },
-            {
-                "label": "private",
-                "section": {"label": "gpg"},
-                "value": "@/tmp/freckles-op-placeholder",
-            },
-            {
-                "label": "key_id",
-                "section": {"label": "gpg"},
-                "value": "",
-            },
-            {
-                "label": "fingerprint",
-                "section": {"label": "gpg"},
-                "value": "",
-            },
-        ]
-    }
-
-
-def test_import_remote_key_ignores_placeholder(monkeypatch):
-    account = _build_account()
-    commands = []
+def test_discover_secret_key_parses_output(monkeypatch):
+    sample = """
+sec:u:4096:1:ABCDEF1234567890:0:0:::\n
+aaa\n
+fpr:::::::::FINGERPRINT1234567890:\n
+""".strip()
 
     def fake_run(command: str):
-        commands.append(command)
-        return CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+        assert command.startswith("gpg --list-secret-keys")
+        return FakeProcess(returncode=0, stdout=sample)
 
     monkeypatch.setattr(gpg, "run", fake_run)
 
-    assert gpg._import_remote_key(account, _placeholder_item()) is None
-    assert commands == []
+    result = gpg.discover_secret_key("example@example.com")
+    assert result == ("ABCDEF1234567890", "FINGERPRINT1234567890")
 
 
-def test_provision_replaces_placeholder_fields(monkeypatch):
-    account = _build_account()
-    config = AccountConfig(accounts=[account], default_account=account.slug)
-
-    key_id = "ABCDEF1234567890"
-    fingerprint = "FINGERPRINT1234567890"
-
-    item_payload = _placeholder_item()
-
-    def fake_get_item(vault: str, item: str, suppress_missing: bool = False):
-        assert vault == "Vault"
-        assert item == "Item"
-        return item_payload
-
-    updated_fields = []
-
-    def fake_update_item_fields(vault: str, item: str, fields):
-        updated_fields.extend(fields)
-        return True
-
-    saved_configs = []
-
-    def fake_save_account_config(value):
-        saved_configs.append(value)
-
-    commands = []
+def test_export_gpg_material_returns_material(monkeypatch):
+    public_called = []
+    private_called = []
+    fingerprint_called = []
 
     def fake_run(command: str):
-        commands.append(command)
-        if "--generate-key" in command:
-            pytest.fail("Unexpected request to generate a new GPG key")
-        if command.startswith("gpg --list-secret-keys"):
-            payload = (
-                "sec:u:4096:1:ABCDEF1234567890:0:0:::\n"
-                "fpr:::::::::FINGERPRINT1234567890:\n"
-            )
-            return CompletedProcess(args=command, returncode=0, stdout=payload, stderr="")
+        if command.startswith("gpg --armor --export ") and "--export-secret-keys" not in command:
+            public_called.append(command)
+            return FakeProcess(stdout="PUBLIC-KEY\n")
         if command.startswith("gpg --armor --export-secret-keys"):
-            return CompletedProcess(args=command, returncode=0, stdout="PRIVATE-KEY\n", stderr="")
-        if command.startswith("gpg --armor --export"):
-            return CompletedProcess(args=command, returncode=0, stdout="PUBLIC-KEY\n", stderr="")
+            private_called.append(command)
+            return FakeProcess(stdout="PRIVATE-KEY\n")
         if command.startswith("gpg --with-colons --fingerprint"):
+            fingerprint_called.append(command)
             payload = (
                 "sec:u:4096:1:ABCDEF1234567890:0:0:::\n"
                 "fpr:::::::::FINGERPRINT1234567890:\n"
             )
-            return CompletedProcess(args=command, returncode=0, stdout=payload, stderr="")
-        return CompletedProcess(args=command, returncode=1, stdout="", stderr="unexpected command")
+            return FakeProcess(stdout=payload)
+        raise AssertionError(f"Unexpected command: {command}")
 
     monkeypatch.setattr(gpg, "run", fake_run)
-    monkeypatch.setattr(gpg, "ensure_op_connected", lambda: None)
-    monkeypatch.setattr(gpg, "get_item", fake_get_item)
-    monkeypatch.setattr(gpg, "update_item_fields", fake_update_item_fields)
-    monkeypatch.setattr(gpg, "save_account_config", fake_save_account_config)
 
-    updates = gpg.provision_gpg_material(config)
-
-    assert len(updates) == 1
-    updated_account, material = updates[0]
-    assert updated_account is account
-    assert material.key_id == key_id
-    assert material.fingerprint == fingerprint
+    material = gpg.export_gpg_material("ABCDEF1234567890")
+    assert material is not None
+    assert material.key_id == "ABCDEF1234567890"
     assert material.public_key == "PUBLIC-KEY"
     assert material.private_key == "PRIVATE-KEY"
+    assert material.fingerprint == "FINGERPRINT1234567890"
+    assert public_called and private_called and fingerprint_called
 
-    assert saved_configs and saved_configs[0] is config
 
-    assert {field.label for field in updated_fields} == {
-        "public",
-        "private",
-        "key_id",
-        "fingerprint",
-    }
-    for field in updated_fields:
-        assert not field.value.strip().startswith("@")
+def test_export_gpg_material_handles_failure(monkeypatch):
+    def fake_run(command: str):
+        return FakeProcess(returncode=1, stderr="boom")
 
-    assert any(cmd.startswith("gpg --armor --export ") for cmd in commands)
-    assert any(cmd.startswith("gpg --armor --export-secret-keys ") for cmd in commands)
+    monkeypatch.setattr(gpg, "run", fake_run)
+
+    material = gpg.export_gpg_material("ABCDEF1234567890")
+    assert material is None

--- a/utils/git.py
+++ b/utils/git.py
@@ -12,8 +12,8 @@ from .accounts import (
     ensure_account_config,
     get_account_config as _get_account_config,
 )
-from .gpg import provision_gpg_material
 from .meta import HOME
+from .shared_identity import ensure_shared_gpg_material, publish_public_material
 
 
 IDENTITY_BEGIN = "# >>> freckles global identity >>>"
@@ -145,22 +145,32 @@ def _summarise_accounts(config: AccountConfig) -> None:
 def configure_git() -> AccountConfig:
     download_git_files()
     config = ensure_account_config()
-    gpg_updates = provision_gpg_material(config)
+    shared_gpg = ensure_shared_gpg_material(config)
     _write_account_configs(config)
     _update_gitconfig(config)
     _ensure_git_user_config(config)
     _summarise_accounts(config)
-    if gpg_updates:
-        print(
-            "\nGPG signing keys have been generated/exported. Paste the following public keys into Git hosting services:"
+    if shared_gpg:
+        outputs = publish_public_material(None, shared_gpg)
+        public_path = outputs.get("gpg_public")
+        fingerprint_path = outputs.get("gpg_fingerprint")
+        key_id_path = outputs.get("gpg_key_id")
+        message = [
+            "\nShared GPG signing key configured locally.",
+            f"  Key ID: {shared_gpg.material.key_id}",
+        ]
+        if shared_gpg.material.fingerprint:
+            message.append(f"  Fingerprint: {shared_gpg.material.fingerprint}")
+        if public_path:
+            message.append(f"  Public key: {public_path}")
+        if fingerprint_path:
+            message.append(f"  Fingerprint file: {fingerprint_path}")
+        if key_id_path:
+            message.append(f"  Key id file: {key_id_path}")
+        message.append(
+            "Upload this public key to your Git hosting services to enable commit signing."
         )
-        for account, material in gpg_updates:
-            print(
-                f"\n[{account.provider} | {account.display_name} ({account.scope})] Key ID: {material.key_id}"
-            )
-            print(material.public_key)
-            if material.fingerprint:
-                print(f"Fingerprint: {material.fingerprint}")
+        print("\n".join(message))
     return config
 
 

--- a/utils/gpg.py
+++ b/utils/gpg.py
@@ -1,4 +1,4 @@
-"""Helpers to provision and export GPG material for git identities."""
+"""Helpers to discover, generate, and export GPG key material."""
 
 from __future__ import annotations
 
@@ -6,74 +6,9 @@ import shlex
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Optional, Tuple
 
-
-def _has_material_value(value: Optional[str]) -> bool:
-    """Return ``True`` when ``value`` appears to contain actual key material."""
-
-    if value is None:
-        return False
-
-    stripped = value.strip()
-    if not stripped:
-        return False
-
-    if stripped.startswith("@"):
-        remainder = stripped[1:]
-        if not remainder:
-            return False
-        if remainder.startswith(("/", "\\", "~")):
-            return False
-        if len(remainder) >= 2 and remainder[1] == ":" and remainder[0].isalpha():
-            return False
-
-    return True
-
-
-def _looks_like_pgp_public_key(value: Optional[str]) -> bool:
-    """Return ``True`` when ``value`` resembles an exported PGP public key."""
-
-    if value is None:
-        return False
-
-    text = value.strip()
-    if not text:
-        return False
-
-    begin = "-----BEGIN PGP PUBLIC KEY BLOCK-----"
-    end = "-----END PGP PUBLIC KEY BLOCK-----"
-    return text.startswith(begin) and end in text
-
-
-def _looks_like_pgp_private_key(value: Optional[str]) -> bool:
-    """Return ``True`` when ``value`` resembles an exported PGP private key."""
-
-    if value is None:
-        return False
-
-    text = value.strip()
-    if not text:
-        return False
-
-    private_markers = [
-        ("-----BEGIN PGP PRIVATE KEY BLOCK-----", "-----END PGP PRIVATE KEY BLOCK-----"),
-        ("-----BEGIN PGP SECRET KEY BLOCK-----", "-----END PGP SECRET KEY BLOCK-----"),
-    ]
-    for begin, end in private_markers:
-        if text.startswith(begin) and end in text:
-            return True
-    return False
-
-from .accounts import AccountConfig, GitAccount, save_account_config
 from .debian import run
-from .one_password import (
-    OnePasswordField,
-    ensure_op_connected,
-    get_field_value,
-    get_item,
-    update_item_fields,
-)
 
 
 @dataclass
@@ -107,44 +42,19 @@ def _parse_secret_key(output: str) -> Optional[Tuple[str, str]]:
     return None
 
 
-def _discover_existing_key(account: GitAccount) -> Optional[Tuple[str, str]]:
-    result = run(
-        f'gpg --list-secret-keys --with-colons --fingerprint "{account.email}"'
-    )
+def discover_secret_key(query: str) -> Optional[Tuple[str, str]]:
+    """Return the key id and fingerprint for a matching secret key."""
+
+    command = f"gpg --list-secret-keys --with-colons --fingerprint {shlex.quote(query)}"
+    result = run(command)
     if result.returncode != 0:
         return None
     return _parse_secret_key(result.stdout or "")
 
 
-def _import_remote_key(account: GitAccount, item: Optional[Dict]) -> Optional[Tuple[str, str]]:
-    if not item:
-        return None
+def generate_secret_key(name: str, email: str) -> Optional[Tuple[str, str]]:
+    """Generate a new secret key for the supplied identity."""
 
-    private_key = get_field_value(item, "gpg", "private") or ""
-    if not _looks_like_pgp_private_key(private_key):
-        return None
-
-    with tempfile.NamedTemporaryFile("w", delete=False) as handle:
-        temp_path = Path(handle.name)
-        handle.write(private_key.strip() + "\n")
-
-    try:
-        result = run(f"gpg --batch --import {shlex.quote(temp_path.as_posix())}")
-    finally:
-        temp_path.unlink(missing_ok=True)
-
-    if result.returncode != 0:
-        message = result.stderr.strip() or result.stdout.strip() or "unknown error"
-        print(
-            f"Failed to import GPG key for {account.display_name} "
-            f"({account.email}) from 1Password: {message}"
-        )
-        return None
-
-    return _discover_existing_key(account)
-
-
-def _generate_key(account: GitAccount) -> Optional[Tuple[str, str]]:
     template = """
 Key-Type: RSA
 Key-Length: 4096
@@ -155,7 +65,7 @@ Name-Email: {email}
 Expire-Date: 0
 %no-protection
 %commit
-""".strip().format(name=account.display_name, email=account.email)
+""".strip().format(name=name, email=email)
 
     with tempfile.NamedTemporaryFile("w", delete=False) as handle:
         template_path = Path(handle.name)
@@ -167,15 +77,19 @@ Expire-Date: 0
     if result.returncode != 0:
         message = result.stderr.strip() or result.stdout.strip() or "unknown error"
         print(
-            f"Failed to generate GPG key for {account.display_name} "
-            f"({account.email}): {message}"
+            f"Failed to generate GPG key for {name} ({email}): {message}"
         )
         return None
 
-    return _discover_existing_key(account)
+    lookup = discover_secret_key(email)
+    if lookup is None:
+        return None
+    return lookup
 
 
-def _export_material(key_id: str) -> Optional[GpgMaterial]:
+def export_gpg_material(key_id: str) -> Optional[GpgMaterial]:
+    """Export public and private key material for ``key_id``."""
+
     public_result = run(f"gpg --armor --export {key_id}")
     if public_result.returncode != 0:
         message = public_result.stderr.strip() or public_result.stdout.strip() or "unknown error"
@@ -204,137 +118,3 @@ def _export_material(key_id: str) -> Optional[GpgMaterial]:
         private_key=(private_result.stdout or "").strip(),
     )
 
-
-def _needs_update(
-    item: Optional[Dict],
-    field: str,
-    *,
-    expected: Optional[str] = None,
-    validator: Optional[Callable[[Optional[str]], bool]] = None,
-) -> bool:
-    if not item:
-        return True
-    value = get_field_value(item, "gpg", field)
-    if validator and validator(value):
-        return False
-    if not _has_material_value(value):
-        return True
-    if expected is None:
-        return False
-    return (value or "").strip() != expected.strip()
-
-
-def provision_gpg_material(config: AccountConfig) -> List[Tuple[GitAccount, GpgMaterial]]:
-    """Ensure each account has exported GPG material stored in 1Password."""
-
-    eligible_accounts = [
-        account
-        for account in config.accounts
-        if account.op_vault and account.op_item
-    ]
-    if not eligible_accounts:
-        return []
-
-    ensure_op_connected()
-    updated_material: List[Tuple[GitAccount, GpgMaterial]] = []
-    config_updated = False
-
-    for account in eligible_accounts:
-        item = get_item(account.op_vault, account.op_item, suppress_missing=True)
-        remote_public = (get_field_value(item, "gpg", "public") or "") if item else ""
-        remote_private = (get_field_value(item, "gpg", "private") or "") if item else ""
-        remote_public_valid = _looks_like_pgp_public_key(remote_public)
-        remote_private_valid = _looks_like_pgp_private_key(remote_private)
-        remote_has_material = remote_public_valid and remote_private_valid
-        details = _discover_existing_key(account)
-        generated_new_key = False
-        if details is None and remote_private_valid:
-            details = _import_remote_key(account, item)
-            if details is None:
-                continue
-        if details is None and remote_public_valid and not remote_private_valid:
-            print(
-                "Skipping GPG provisioning for"
-                f" {account.display_name} ({account.email}) because the"
-                " 1Password item contains a GPG public key but the private key is"
-                " missing or malformed. Manual intervention is required."
-            )
-            continue
-        if details is None:
-            details = _generate_key(account)
-            generated_new_key = details is not None
-        if details is None:
-            continue
-
-        key_id, fingerprint = details
-        material: Optional[GpgMaterial] = None
-        if not remote_has_material:
-            material = _export_material(key_id)
-            if material is None:
-                continue
-
-        signing_changed = False
-        if not account.signing_key or account.signing_key != key_id:
-            account.signing_key = key_id
-            config_updated = True
-            signing_changed = True
-
-        fields: List[OnePasswordField] = []
-        if material is not None:
-            if _needs_update(
-                item,
-                "public",
-                expected=material.public_key,
-                validator=_looks_like_pgp_public_key,
-            ):
-                fields.append(
-                    OnePasswordField(
-                        section="gpg",
-                        label="public",
-                        value=material.public_key + "\n",
-                    )
-                )
-            if _needs_update(
-                item,
-                "private",
-                expected=material.private_key,
-                validator=_looks_like_pgp_private_key,
-            ):
-                fields.append(
-                    OnePasswordField(
-                        section="gpg",
-                        label="private",
-                        value=material.private_key + "\n",
-                        concealed=True,
-                    )
-                )
-        if _needs_update(item, "key_id", expected=key_id):
-            fields.append(
-                OnePasswordField(
-                    section="gpg",
-                    label="key_id",
-                    value=key_id,
-                )
-            )
-        if fingerprint and _needs_update(item, "fingerprint", expected=fingerprint):
-            fields.append(
-                OnePasswordField(
-                    section="gpg",
-                    label="fingerprint",
-                    value=fingerprint,
-                )
-            )
-
-        fields_updated = False
-        if fields:
-            fields_updated = update_item_fields(account.op_vault, account.op_item, fields)
-            if fields_updated:
-                item = get_item(account.op_vault, account.op_item)
-
-        if material and (generated_new_key or fields_updated or signing_changed):
-            updated_material.append((account, material))
-
-    if config_updated:
-        save_account_config(config)
-
-    return updated_material

--- a/utils/shared_identity.py
+++ b/utils/shared_identity.py
@@ -1,0 +1,208 @@
+"""Helpers for provisioning shared SSH and GPG identity material."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+from .accounts import AccountConfig, save_account_config
+from .debian import run
+from .gpg import GpgMaterial, discover_secret_key, export_gpg_material, generate_secret_key
+from .meta import CONFIG_DIR, HOME, SSH_DIR
+
+
+IDENTITY_DIR = CONFIG_DIR / "identity"
+PUBLIC_EXPORT_DIR = HOME / "Public" / "git-keys"
+SHARED_SSH_KEY_PATH = SSH_DIR / "id_freckles_shared"
+GPG_MARKER_PATH = IDENTITY_DIR / "gpg-key-id"
+
+
+@dataclass
+class SharedSshMaterial:
+    """Details about the shared SSH key that was ensured on disk."""
+
+    private_key_path: Path
+    public_key_path: Path
+    public_key: str
+    fingerprint: str
+    created: bool
+
+
+@dataclass
+class SharedGpgMaterial:
+    """Information about the shared GPG key material."""
+
+    material: GpgMaterial
+    created: bool
+
+
+def _ensure_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text().strip()
+    except FileNotFoundError:
+        return ""
+
+
+def _ensure_permissions(private_path: Path, public_path: Path) -> None:
+    try:
+        private_path.chmod(0o600)
+    except FileNotFoundError:
+        pass
+    try:
+        public_path.chmod(0o644)
+    except FileNotFoundError:
+        pass
+
+
+def _fingerprint_for_public_key(public_path: Path) -> str:
+    command = f"ssh-keygen -lf {shlex.quote(public_path.as_posix())}"
+    result = run(command)
+    if result.returncode != 0:
+        return ""
+    stdout = (result.stdout or "").strip().splitlines()
+    if not stdout:
+        return ""
+    parts = stdout[0].split()
+    if len(parts) >= 2:
+        return parts[1]
+    return stdout[0]
+
+
+def ensure_shared_ssh_key(email: str) -> Optional[SharedSshMaterial]:
+    """Ensure an SSH key exists for the supplied email address."""
+
+    _ensure_directory(SSH_DIR)
+    key_path = SHARED_SSH_KEY_PATH
+    public_path = key_path.with_suffix(".pub")
+    created = False
+
+    if not key_path.exists() or not public_path.exists():
+        command = " ".join(
+            [
+                "ssh-keygen",
+                "-t",
+                "ed25519",
+                "-C",
+                shlex.quote(email),
+                "-f",
+                shlex.quote(key_path.as_posix()),
+                "-N",
+                "''",
+            ]
+        )
+        result = run(command)
+        if result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip() or "unknown error"
+            print(f"Failed to generate shared SSH key: {message}")
+            return None
+        created = True
+
+    _ensure_permissions(key_path, public_path)
+
+    public_key = _read_text(public_path)
+    if not public_key:
+        return None
+
+    fingerprint = _fingerprint_for_public_key(public_path)
+
+    return SharedSshMaterial(
+        private_key_path=key_path,
+        public_key_path=public_path,
+        public_key=public_key,
+        fingerprint=fingerprint,
+        created=created,
+    )
+
+
+def ensure_shared_gpg_material(config: AccountConfig) -> Optional[SharedGpgMaterial]:
+    """Ensure a shared GPG key exists and update account configuration."""
+
+    if not config.accounts:
+        return None
+
+    _ensure_directory(IDENTITY_DIR)
+    default_account = config.get_default()
+    marker_key = _read_text(GPG_MARKER_PATH)
+    created = False
+    lookup: Optional[tuple[str, str]] = None
+
+    if marker_key:
+        lookup = discover_secret_key(marker_key)
+        if lookup is None:
+            marker_key = ""
+
+    if not lookup:
+        lookup = discover_secret_key(default_account.email)
+
+    if not lookup:
+        lookup = generate_secret_key(default_account.display_name, default_account.email)
+        created = lookup is not None
+
+    if not lookup:
+        print("Unable to locate or generate a shared GPG key for commit signing.")
+        return None
+
+    key_id, _fingerprint = lookup
+    material = export_gpg_material(key_id)
+    if material is None:
+        print(f"Failed to export shared GPG key material for {key_id}.")
+        return None
+
+    if material.key_id and material.key_id != key_id:
+        key_id = material.key_id
+
+    if material.key_id:
+        GPG_MARKER_PATH.write_text(material.key_id.strip() + "\n")
+
+    config_updated = False
+    for account in config.accounts:
+        if account.signing_key != material.key_id:
+            account.signing_key = material.key_id
+            config_updated = True
+
+    if config_updated:
+        save_account_config(config)
+
+    return SharedGpgMaterial(material=material, created=created)
+
+
+def publish_public_material(
+    ssh_material: Optional[SharedSshMaterial],
+    gpg_material: Optional[SharedGpgMaterial],
+) -> Dict[str, Path]:
+    """Write exported material to a predictable directory for user access."""
+
+    _ensure_directory(PUBLIC_EXPORT_DIR)
+    outputs: Dict[str, Path] = {}
+
+    if ssh_material:
+        ssh_public = PUBLIC_EXPORT_DIR / "ssh.pub"
+        ssh_public.write_text(ssh_material.public_key.strip() + "\n")
+        outputs["ssh_public"] = ssh_public
+        if ssh_material.fingerprint:
+            ssh_fingerprint = PUBLIC_EXPORT_DIR / "ssh.fingerprint"
+            ssh_fingerprint.write_text(ssh_material.fingerprint.strip() + "\n")
+            outputs["ssh_fingerprint"] = ssh_fingerprint
+
+    if gpg_material:
+        gpg_public = PUBLIC_EXPORT_DIR / "gpg.asc"
+        gpg_public.write_text(gpg_material.material.public_key.strip() + "\n")
+        outputs["gpg_public"] = gpg_public
+        key_id_path = PUBLIC_EXPORT_DIR / "gpg.key-id"
+        key_id_path.write_text(gpg_material.material.key_id.strip() + "\n")
+        outputs["gpg_key_id"] = key_id_path
+        if gpg_material.material.fingerprint:
+            gpg_fingerprint = PUBLIC_EXPORT_DIR / "gpg.fingerprint"
+            gpg_fingerprint.write_text(
+                gpg_material.material.fingerprint.strip() + "\n"
+            )
+            outputs["gpg_fingerprint"] = gpg_fingerprint
+
+    return outputs
+

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -2,29 +2,25 @@
 
 from __future__ import annotations
 
+import re
 import shlex
 import sys
-import tempfile
 import textwrap
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from .accounts import GitAccount, get_account_config, save_account_config
 from .debian import run
-from .meta import KNOWN_HOSTS, SSH_CONFIG, SSH_DIR
+from .meta import HOME, KNOWN_HOSTS, SSH_CONFIG, SSH_DIR
 from .one_password import (
     MultipleItemsFoundError,
-    OnePasswordField,
     OnePasswordItem,
     ensure_op_connected,
     ensure_ssh_container,
-    get_field_value,
-    get_item,
     list_items,
     resolve_item_identifier,
-    update_item_fields,
 )
+from .shared_identity import ensure_shared_ssh_key, publish_public_material
 
 known_hosts_content = textwrap.dedent("""
 gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
@@ -38,243 +34,6 @@ github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+V
 def write_known_hosts() -> None:
     if not KNOWN_HOSTS.exists():
         KNOWN_HOSTS.write_text(known_hosts_content)
-
-
-def _key_paths(account: GitAccount) -> Tuple[Path, Path]:
-    key_path = SSH_DIR / f"{account.slug}.{account.provider}"
-    public_path = key_path.with_suffix(".pub")
-    return key_path, public_path
-
-
-def _read_text(path: Path) -> Optional[str]:
-    try:
-        return path.read_text().strip()
-    except FileNotFoundError:
-        return None
-
-
-def _ensure_permissions(key_path: Path, public_path: Path) -> None:
-    try:
-        key_path.chmod(0o600)
-    except FileNotFoundError:
-        pass
-    try:
-        public_path.chmod(0o644)
-    except FileNotFoundError:
-        pass
-
-
-def _generate_local_key(account: GitAccount, key_path: Path, public_path: Path) -> bool:
-    SSH_DIR.mkdir(parents=True, exist_ok=True)
-    if key_path.exists():
-        key_path.unlink()
-    if public_path.exists():
-        public_path.unlink()
-
-    command = " ".join(
-        [
-            "ssh-keygen",
-            "-t",
-            "ed25519",
-            "-C",
-            shlex.quote(account.email),
-            "-f",
-            shlex.quote(key_path.as_posix()),
-            "-N",
-            "''",
-        ]
-    )
-    result = run(command)
-    if result.returncode != 0:
-        message = result.stderr.strip() or result.stdout.strip() or "unknown error"
-        print(
-            f"Failed to generate SSH key for {account.display_name} "
-            f"({account.provider}): {message}"
-        )
-        return False
-
-    _ensure_permissions(key_path, public_path)
-    return True
-
-
-def _fingerprint(public_path: Path) -> str:
-    result = run(f'ssh-keygen -lf {shlex.quote(public_path.as_posix())}')
-    if result.returncode != 0:
-        return ""
-    line = (result.stdout or "").strip().splitlines()
-    if not line:
-        return ""
-    parts = line[0].split()
-    if len(parts) >= 2:
-        return parts[1]
-    return line[0]
-
-
-def _fingerprint_from_text(public_key: str) -> str:
-    if not public_key.strip():
-        return ""
-
-    with tempfile.NamedTemporaryFile("w", delete=False) as handle:
-        temp_path = Path(handle.name)
-        handle.write(public_key.strip() + "\n")
-
-    try:
-        return _fingerprint(temp_path)
-    finally:
-        temp_path.unlink(missing_ok=True)
-
-
-def _provision_ssh_material(account: GitAccount) -> Optional[SshMaterial]:
-    if not account.op_vault or not account.op_item:
-        return None
-
-    item = get_item(account.op_vault, account.op_item, suppress_missing=True)
-    key_path, public_path = _key_paths(account)
-    local_private = _read_text(key_path)
-    local_public = _read_text(public_path)
-
-    remote_public_raw = get_field_value(item, "ssh", "public") or ""
-    remote_private_raw = get_field_value(item, "ssh", "private") or ""
-    remote_fingerprint = get_field_value(item, "ssh", "fingerprint") or ""
-
-    remote_public_valid = _looks_like_public_key(remote_public_raw)
-    remote_private_valid = _looks_like_private_key(remote_private_raw)
-
-    remote_public = remote_public_raw.strip() if remote_public_valid else ""
-    remote_private = remote_private_raw.strip() if remote_private_valid else ""
-
-    if not local_public and remote_public_valid:
-        local_public = remote_public
-    if not local_private and remote_private_valid:
-        local_private = remote_private
-
-    derived_public: Optional[str] = None
-    if remote_private_valid and (not remote_public_valid or not local_public):
-        derived_public = _derive_public_from_private(remote_private)
-        if derived_public and not local_public:
-            local_public = derived_public.strip()
-
-    if remote_public_valid and not remote_private_valid and not local_private:
-        print(
-            "Skipping SSH provisioning for"
-            f" {account.display_name} ({account.provider}) because the"
-            " 1Password item contains an SSH public key but the private key is"
-            " missing or malformed. Manual intervention is required."
-        )
-        return None
-
-    created = False
-    should_generate = (
-        not remote_public_valid
-        and not remote_private_valid
-        and (not local_public or not local_private)
-    )
-
-    if should_generate:
-        generated = _generate_local_key(account, key_path, public_path)
-        if not generated:
-            return None
-        created = True
-        local_private = _read_text(key_path)
-        local_public = _read_text(public_path)
-
-    if not local_public or not local_private:
-        return None
-
-    _ensure_permissions(key_path, public_path)
-
-    fingerprint = ""
-    if public_path.exists():
-        fingerprint = _fingerprint(public_path)
-    if not fingerprint:
-        fingerprint = _fingerprint_from_text(local_public)
-    if not fingerprint and remote_fingerprint.strip():
-        fingerprint = remote_fingerprint.strip()
-
-    fields: List[OnePasswordField] = []
-    if created:
-        fields.extend(
-            [
-                OnePasswordField(
-                    section="ssh",
-                    label="public",
-                    value=local_public + "\n",
-                ),
-                OnePasswordField(
-                    section="ssh",
-                    label="private",
-                    value=local_private + "\n",
-                    concealed=True,
-                ),
-            ]
-        )
-        if fingerprint:
-            fields.append(
-                OnePasswordField(
-                    section="ssh",
-                    label="fingerprint",
-                    value=fingerprint,
-                )
-            )
-    else:
-        if local_public and not remote_public_valid:
-            public_value = (derived_public or local_public).strip()
-            if public_value:
-                fields.append(
-                    OnePasswordField(
-                        section="ssh",
-                        label="public",
-                        value=public_value + "\n",
-                    )
-                )
-        if local_private and not remote_private_valid:
-            fields.append(
-                OnePasswordField(
-                    section="ssh",
-                    label="private",
-                    value=local_private + "\n",
-                    concealed=True,
-                ),
-            )
-        if fingerprint and not remote_fingerprint.strip():
-            fields.append(
-                OnePasswordField(
-                    section="ssh",
-                    label="fingerprint",
-                    value=fingerprint,
-                )
-            )
-
-    missing_item = item is None
-    prepared = ensure_ssh_container(
-        account.op_vault,
-        account.op_item,
-        create_if_missing=missing_item,
-        initial_fields=list(fields) if missing_item else None,
-    )
-    if prepared is None:
-        return None
-    item = prepared
-
-    if missing_item:
-        # ``initial_fields`` already populated the new item with fresh material,
-        # so there is no need to rewrite the same values immediately afterwards.
-        fields = []
-        remote_public = get_field_value(item, "ssh", "public") or ""
-        remote_private = get_field_value(item, "ssh", "private") or ""
-        remote_fingerprint = get_field_value(item, "ssh", "fingerprint") or ""
-
-    updated = False
-    if fields:
-        updated = update_item_fields(account.op_vault, account.op_item, fields)
-
-    return SshMaterial(
-        key_path=key_path,
-        public_key=local_public,
-        fingerprint=fingerprint,
-        updated=missing_item or updated or created,
-        created=created,
-    )
 
 
 def _score_item(account: GitAccount, item: OnePasswordItem) -> int:
@@ -383,35 +142,55 @@ def _auto_assign_items(
     return assignments
 
 
-def _ensure_config_entry(account, existing_config: str) -> str:
-    host_alias = account.ssh_alias
-    if f"Host {host_alias}" in existing_config:
-        return existing_config
+def _format_identity_path(path: Path) -> str:
+    try:
+        return f"~/{path.relative_to(HOME).as_posix()}"
+    except ValueError:
+        return path.as_posix()
 
-    key_path = SSH_DIR / f"{account.slug}.{account.provider}"
-    config_entry = textwrap.dedent(
+
+def _render_host_block(account: GitAccount, identity_file: Path) -> str:
+    identity = _format_identity_path(identity_file)
+    block = textwrap.dedent(
         f"""
-        Host {host_alias}
+        Host {account.ssh_alias}
             HostName {account.provider}.com
             AddKeysToAgent yes
-            IdentityFile ~/.ssh/{key_path.name}
+            IdentityFile {identity}
             User git
         """
     )
-    with SSH_CONFIG.open("a") as fh:
-        fh.write(config_entry)
-    return existing_config + config_entry
+    return block
 
 
-@dataclass
-class SshMaterial:
-    """Details about generated SSH material for an account."""
+def _ensure_config_entry(
+    account: GitAccount,
+    existing_config: str,
+    *,
+    identity_file: Optional[Path] = None,
+) -> Tuple[str, bool]:
+    host_alias = account.ssh_alias
+    identity_path = identity_file or (SSH_DIR / f"{account.slug}.{account.provider}")
+    new_block = _render_host_block(account, identity_path)
+    pattern = re.compile(
+        rf"(^Host {re.escape(host_alias)}\n(?:[\t ].*\n?)*)",
+        re.MULTILINE,
+    )
+    match = pattern.search(existing_config)
+    if match:
+        current_block = match.group(1)
+        if not current_block.endswith("\n"):
+            current_block += "\n"
+        if current_block == new_block:
+            return existing_config, False
+        updated = existing_config[: match.start()] + new_block + existing_config[match.end() :]
+        return updated, True
 
-    key_path: Path
-    public_key: str
-    fingerprint: str
-    updated: bool
-    created: bool
+    updated_config = existing_config
+    if updated_config and not updated_config.endswith("\n"):
+        updated_config += "\n"
+    updated_config += new_block
+    return updated_config, True
 
 
 def _install_keys_for_account(account) -> Tuple[bool, Optional[str]]:
@@ -505,6 +284,52 @@ def configure_ssh():
     write_known_hosts()
     interactive = sys.stdin.isatty()
     config = get_account_config(interactive=interactive)
+    existing_config = SSH_CONFIG.read_text() if SSH_CONFIG.exists() else ""
+    has_one_password = any(
+        account.op_vault and account.op_item for account in config.accounts
+    )
+
+    if not has_one_password:
+        default_account = config.get_default()
+        shared_material = ensure_shared_ssh_key(default_account.email)
+        if shared_material is None:
+            print("Skipping shared SSH setup because the key could not be generated.")
+            return
+        config_changed = False
+        for account in config.accounts:
+            existing_config, changed = _ensure_config_entry(
+                account,
+                existing_config,
+                identity_file=shared_material.private_key_path,
+            )
+            config_changed = config_changed or changed
+        if config_changed:
+            if existing_config and not existing_config.endswith("\n"):
+                existing_config += "\n"
+            SSH_DIR.mkdir(parents=True, exist_ok=True)
+            SSH_CONFIG.write_text(existing_config)
+        add_result = run(
+            f"ssh-add {shlex.quote(shared_material.private_key_path.as_posix())}"
+        )
+        if add_result.returncode != 0:
+            message = add_result.stderr.strip() or add_result.stdout.strip() or "unknown error"
+            print(f"Failed to add shared SSH key to ssh-agent: {message}")
+        outputs = publish_public_material(shared_material, None)
+        public_path = outputs.get("ssh_public")
+        fingerprint_path = outputs.get("ssh_fingerprint")
+        summary = [
+            "\nShared SSH key configured locally.",
+            f"  Host aliases: {', '.join(account.ssh_alias for account in config.accounts)}",
+        ]
+        if public_path:
+            summary.append(f"  Public key: {public_path}")
+        if fingerprint_path and shared_material.fingerprint:
+            summary.append(f"  Fingerprint: {shared_material.fingerprint}")
+            summary.append(f"  Fingerprint file: {fingerprint_path}")
+        summary.append("Upload this public key to your Git hosting services.")
+        print("\n".join(summary))
+        return
+
     accounts_with_items = [
         account for account in config.accounts if account.op_vault and account.op_item
     ]
@@ -514,6 +339,7 @@ def configure_ssh():
 
     catalog: List[OnePasswordItem] = []
     updated_config = False
+    config_changed = False
 
     if accounts_with_items or needs_mapping:
         ensure_op_connected()
@@ -568,12 +394,6 @@ def configure_ssh():
         account for account in config.accounts if not account.op_vault or not account.op_item
     ]
 
-    provisioned: List[Tuple[GitAccount, SshMaterial]] = []
-    for account in accounts_with_items:
-        material = _provision_ssh_material(account)
-        if material and (material.created or material.updated):
-            provisioned.append((account, material))
-    existing_config = SSH_CONFIG.read_text() if SSH_CONFIG.exists() else ""
     SSH_DIR.mkdir(parents=True, exist_ok=True)
 
     if needs_mapping:
@@ -618,7 +438,8 @@ def configure_ssh():
             continue
         success, error = _install_keys_for_account(account)
         if success:
-            existing_config = _ensure_config_entry(account, existing_config)
+            existing_config, changed = _ensure_config_entry(account, existing_config)
+            config_changed = config_changed or changed
         elif error:
             failures[account.slug] = error
             print(error)
@@ -638,7 +459,8 @@ def configure_ssh():
             updated_config = True
             success, error = _install_keys_for_account(account)
             if success:
-                existing_config = _ensure_config_entry(account, existing_config)
+                existing_config, changed = _ensure_config_entry(account, existing_config)
+                config_changed = config_changed or changed
                 failures.pop(account.slug, None)
             elif error:
                 failures[account.slug] = error
@@ -651,83 +473,9 @@ def configure_ssh():
         print("\nSome SSH keys could not be installed:")
         for message in failures.values():
             print(f"  - {message}")
-    if provisioned:
-        print(
-            "\nSSH key material has been synchronised with 1Password. Paste the following public keys into the matching Git hosts:"
-        )
-        for account, material in provisioned:
-            action = "Generated" if material.created else "Updated"
-            print(
-                f"\n[{account.provider} | {account.display_name} ({account.scope})] "
-                f"({action}) -> {material.key_path.with_suffix('.pub')}"
-            )
-            print(material.public_key)
-            if material.fingerprint:
-                print(f"Fingerprint: {material.fingerprint}")
+    if config_changed:
+        if existing_config and not existing_config.endswith("\n"):
+            existing_config += "\n"
+        SSH_CONFIG.write_text(existing_config)
 
-
-def _looks_like_public_key(value: Optional[str]) -> bool:
-    """Return ``True`` when ``value`` resembles an SSH public key."""
-
-    if value is None:
-        return False
-
-    text = value.strip()
-    if not text:
-        return False
-
-    parts = text.split()
-    if len(parts) < 2:
-        return False
-
-    prefix = parts[0].lower()
-    valid_prefixes = (
-        "ssh-",
-        "ecdsa-",
-        "sk-",
-        "ecdsa-sk-",
-    )
-    return any(prefix.startswith(candidate) for candidate in valid_prefixes)
-
-
-def _looks_like_private_key(value: Optional[str]) -> bool:
-    """Return ``True`` when ``value`` resembles an SSH private key."""
-
-    if value is None:
-        return False
-
-    text = value.strip()
-    if not text:
-        return False
-
-    if "-----BEGIN" not in text or "PRIVATE KEY-----" not in text:
-        return False
-
-    return "-----END" in text and "PRIVATE KEY-----" in text.split("-----END")[-1]
-
-
-def _derive_public_from_private(private_key: str) -> Optional[str]:
-    """Return the public key derived from ``private_key`` when possible."""
-
-    if not private_key.strip():
-        return None
-
-    with tempfile.NamedTemporaryFile("w", delete=False) as handle:
-        temp_path = Path(handle.name)
-        handle.write(private_key.strip() + "\n")
-
-    try:
-        result = run(
-            "ssh-keygen -y -f " + shlex.quote(temp_path.as_posix())
-        )
-    finally:
-        temp_path.unlink(missing_ok=True)
-
-    if result.returncode != 0:
-        return None
-
-    output = (result.stdout or "").strip()
-    if not output:
-        return None
-    return output
 

--- a/utils/ssh.py
+++ b/utils/ssh.py
@@ -179,11 +179,56 @@ def _ensure_config_entry(
     match = pattern.search(existing_config)
     if match:
         current_block = match.group(1)
-        if not current_block.endswith("\n"):
-            current_block += "\n"
-        if current_block == new_block:
+        normalized_current = current_block
+        if not normalized_current.endswith("\n"):
+            normalized_current += "\n"
+
+        identity_line = f"    IdentityFile {_format_identity_path(identity_path)}"
+        identity_value = identity_line.split(None, 1)[1]
+        slug_fragment = f"{account.slug}.{account.provider}"
+        identity_pattern = re.compile(r"^(\s*)IdentityFile\s+(.+)$", re.IGNORECASE)
+
+        lines = normalized_current.rstrip("\n").split("\n")
+        header, *rest = lines
+        new_rest = []
+        identity_present = False
+
+        for line in rest:
+            match_identity = identity_pattern.match(line)
+            if not match_identity:
+                new_rest.append(line)
+                continue
+
+            indent, value = match_identity.groups()
+            value = value.strip()
+            unquoted = value.strip('"\'')
+
+            if unquoted == identity_value:
+                identity_present = True
+                new_rest.append(f"{indent}IdentityFile {identity_value}")
+                continue
+
+            if slug_fragment in unquoted:
+                identity_present = True
+                if unquoted != identity_value:
+                    new_rest.append(f"{indent}IdentityFile {identity_value}")
+                else:
+                    new_rest.append(line)
+                continue
+
+            new_rest.append(line)
+
+        if not identity_present:
+            new_rest.append(identity_line)
+
+        updated_block = "\n".join([header] + new_rest)
+        if not updated_block.endswith("\n"):
+            updated_block += "\n"
+
+        if updated_block == normalized_current:
             return existing_config, False
-        updated = existing_config[: match.start()] + new_block + existing_config[match.end() :]
+
+        updated = existing_config[: match.start()] + updated_block + existing_config[match.end() :]
         return updated, True
 
     updated_config = existing_config


### PR DESCRIPTION
## Summary
- simplify the GPG helper to drop 1Password provisioning logic and rely on local exports
- update SSH configuration to stop writing back to 1Password items while keeping shared key support
- refresh the git configuration flow and tests to reflect the local-only identity workflow

## Testing
- pytest tests/test_gpg.py

------
https://chatgpt.com/codex/tasks/task_e_69073cd9e2ac832e957f952d93e8d31a