### PR TITLE
Add GNOME desktop configuration and enhance VS Code defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Mostly hand-rolled bash scripts for intalling and configuring my system.
 
 - installs and configures zsh with `--zsh`
 - installs and configures vscode (including extensions) with `--vscode`
+- applies opinionated GNOME desktop settings (dark theme, Night Light, keyboard shortcuts)
 - installs and configures git, including both my personal and work configs with `--git`
   - ships helper aliases like `git fs` for a clean branch reset, `git rb` for
     remote branch discovery, and `git db` for default-branch detection

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ from utils.firefox import (
     setup_mozilla_repo,
 )
 from utils.git import configure_git
+from utils.gnome import configure_gnome
 from utils.shell import configure_shell
 from utils.ssh import configure_ssh
 from utils.vscode import configure_vscode
@@ -131,6 +132,7 @@ configure_vscode()
 configure_git()
 configure_ssh()
 configure_shell()
+configure_gnome()
 manage_avatar()
 if is_debian_12_bookworm() is True:
     replace_bookworm_with_trixie()

--- a/tests/test_gnome.py
+++ b/tests/test_gnome.py
@@ -1,0 +1,69 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utils import gnome  # noqa: E402
+
+
+class FakeProcess:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_configure_gnome_requires_gsettings(monkeypatch):
+    called = []
+
+    def fake_apply(*args, **kwargs):
+        called.append((args, kwargs))
+        return FakeProcess()
+
+    monkeypatch.setattr(gnome, "which", lambda _: None)
+    monkeypatch.setattr(gnome, "_apply_setting", fake_apply)
+
+    gnome.configure_gnome()
+
+    assert called == []
+
+
+def test_configure_gnome_applies_curated_settings(monkeypatch):
+    commands = []
+
+    def fake_apply(schema: str, key: str, value: str):
+        commands.append((schema, key, value))
+        return FakeProcess()
+
+    monkeypatch.setattr(gnome, "which", lambda _: "/usr/bin/gsettings")
+    monkeypatch.setattr(gnome, "_apply_setting", fake_apply)
+
+    gnome.configure_gnome()
+
+    assert ("org.gnome.desktop.interface", "clock-show-date", "true") in commands
+
+    favorite_apps = (
+        "org.gnome.shell",
+        "favorite-apps",
+        "['firefox.desktop', 'code.desktop', 'org.gnome.Nautilus.desktop', "
+        "'org.gnome.Terminal.desktop', 'org.gnome.Calculator.desktop']",
+    )
+    assert favorite_apps in commands
+
+    terminal_binding_path = f"{gnome.CUSTOM_KEYBINDING_ROOT}/launch-terminal/"
+    terminal_binding = (
+        f"{gnome.CUSTOM_KEYBINDING_SCHEMA}:{terminal_binding_path}",
+        "command",
+        "'gnome-terminal'",
+    )
+    assert terminal_binding in commands
+
+    custom_list_entry = (
+        "org.gnome.settings-daemon.plugins.media-keys",
+        "custom-keybindings",
+        "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/launch-terminal/', "
+        "'/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/launch-vscode/']",
+    )
+    assert custom_list_entry in commands

--- a/utils/gnome.py
+++ b/utils/gnome.py
@@ -1,0 +1,119 @@
+"""Utilities for applying curated GNOME desktop preferences."""
+
+from __future__ import annotations
+
+from shutil import which
+from subprocess import CompletedProcess, run
+from typing import Iterable, Sequence
+
+GNOME_SETTINGS: Sequence[tuple[str, str, str]] = (
+    ("org.gnome.desktop.interface", "clock-show-date", "true"),
+    ("org.gnome.desktop.interface", "clock-show-weekday", "true"),
+    ("org.gnome.desktop.interface", "clock-format", "'24h'"),
+    ("org.gnome.desktop.interface", "color-scheme", "'prefer-dark'"),
+    ("org.gnome.desktop.interface", "enable-hot-corners", "false"),
+    (
+        "org.gnome.desktop.interface",
+        "monospace-font-name",
+        "'Cascadia Code 11'",
+    ),
+    ("org.gnome.desktop.interface", "text-scaling-factor", "1.05"),
+    ("org.gnome.desktop.media-handling", "automount", "false"),
+    ("org.gnome.desktop.media-handling", "automount-open", "false"),
+    ("org.gnome.desktop.peripherals.keyboard", "repeat-interval", "25"),
+    ("org.gnome.desktop.peripherals.keyboard", "delay", "250"),
+    ("org.gnome.desktop.peripherals.touchpad", "tap-to-click", "true"),
+    (
+        "org.gnome.desktop.peripherals.touchpad",
+        "two-finger-scrolling-enabled",
+        "true",
+    ),
+    ("org.gnome.desktop.session", "idle-delay", "900"),
+    ("org.gnome.desktop.sound", "event-sounds", "false"),
+    ("org.gnome.desktop.sound", "allow-volume-above-100-percent", "true"),
+    ("org.gnome.desktop.wm.preferences", "button-layout", "'appmenu:minimize,maximize,close'"),
+    ("org.gnome.desktop.wm.preferences", "focus-new-windows", "'smart'"),
+    ("org.gnome.desktop.wm.preferences", "resize-with-right-button", "true"),
+    ("org.gnome.mutter", "center-new-windows", "true"),
+    ("org.gnome.mutter", "edge-tiling", "true"),
+    ("org.gnome.shell", "favorite-apps", "['firefox.desktop', 'code.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop', 'org.gnome.Calculator.desktop']"),
+    ("org.gnome.shell.app-switcher", "current-workspace-only", "true"),
+    ("org.gnome.settings-daemon.plugins.color", "night-light-enabled", "true"),
+    ("org.gnome.settings-daemon.plugins.color", "night-light-temperature", "3700"),
+    ("org.gnome.settings-daemon.plugins.power", "sleep-inactive-ac-type", "'nothing'"),
+    ("org.gnome.settings-daemon.plugins.power", "sleep-inactive-battery-timeout", "1800"),
+    ("org.gnome.settings-daemon.plugins.power", "sleep-inactive-battery-type", "'suspend'"),
+)
+
+CUSTOM_KEYBINDING_SCHEMA = (
+    "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding"
+)
+CUSTOM_KEYBINDING_ROOT = (
+    "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings"
+)
+CUSTOM_KEYBINDINGS: Sequence[dict[str, str]] = (
+    {
+        "slug": "launch-terminal",
+        "name": "Launch Terminal",
+        "command": "gnome-terminal",
+        "binding": "<Super>Return",
+    },
+    {
+        "slug": "launch-vscode",
+        "name": "Launch VS Code",
+        "command": "code",
+        "binding": "<Super>e",
+    },
+)
+
+
+def configure_gnome() -> None:
+    """Apply a curated set of GNOME desktop preferences if available."""
+
+    if which("gsettings") is None:
+        # GNOME is not installed or ``gsettings`` is unavailable.
+        return
+
+    for schema, key, value in GNOME_SETTINGS:
+        _apply_setting(schema, key, value)
+
+    _configure_custom_keybindings(CUSTOM_KEYBINDINGS)
+
+
+def _configure_custom_keybindings(bindings: Iterable[dict[str, str]]) -> None:
+    bindings = list(bindings)
+    if not bindings:
+        return
+
+    binding_paths = [
+        f"{CUSTOM_KEYBINDING_ROOT}/{binding['slug']}/" for binding in bindings
+    ]
+
+    list_literal = "[" + ", ".join(f"'{path}'" for path in binding_paths) + "]"
+    _apply_setting(
+        "org.gnome.settings-daemon.plugins.media-keys",
+        "custom-keybindings",
+        list_literal,
+    )
+
+    for binding, path in zip(bindings, binding_paths, strict=True):
+        schema = f"{CUSTOM_KEYBINDING_SCHEMA}:{path}"
+        _apply_setting(schema, "name", f"'{binding['name']}'")
+        _apply_setting(schema, "command", f"'{binding['command']}'")
+        _apply_setting(schema, "binding", f"'{binding['binding']}'")
+
+
+def _apply_setting(schema: str, key: str, value: str) -> CompletedProcess[str]:
+    result = run(
+        ["gsettings", "set", schema, key, value],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout or "").strip()
+        if message:
+            print(f"Failed to apply {schema} {key}: {message}")
+        else:
+            print(f"Failed to apply {schema} {key}")
+    return result

--- a/vscode/settings.link.json
+++ b/vscode/settings.link.json
@@ -21,6 +21,11 @@
       111
     ]
   },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.quickSuggestions": false,
+    "editor.wordWrap": "on"
+  },
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.tabSize": 4,
@@ -70,10 +75,13 @@
   "editor.dragAndDrop": false,
   "editor.emptySelectionClipboard": false,
   "editor.experimental.asyncTokenization": true,
+  "editor.foldingImports": true,
   "editor.fontFamily": "'Cascadia Code', 'Fira Code', 'Droid Sans Mono', 'monospace', monospace",
   "editor.fontLigatures": true,
+  "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
   "editor.guides.bracketPairs": true,
+  "editor.guides.highlightActiveBracketPair": true,
   "editor.padding.bottom": 26,
   "editor.padding.top": 26,
   "editor.renderLineHighlight": "all",
@@ -87,14 +95,21 @@
   "editor.scrollbar.horizontalScrollbarSize": 18,
   "editor.scrollBeyondLastLine": false,
   "editor.smoothScrolling": true,
+  "editor.stickyScroll.enabled": true,
   "editor.tabCompletion": "on",
   "editor.tabSize": 2,
+  "editor.unicodeHighlight.ambiguousCharacters": false,
+  "editor.unicodeHighlight.invisibleCharacters": false,
+  "editor.unicodeHighlight.nonBasicASCII": false,
   "editor.unusualLineTerminators": "auto",
+  "editor.wordWrapColumn": 110,
   "emmet.includeLanguages": {
     "javascript": "javascriptreact"
   },
   "emmet.triggerExpansionOnTab": true,
   "explorer.confirmDelete": false,
+  "explorer.confirmDragAndDrop": false,
+  "explorer.autoReveal": false,
   "extensions.ignoreRecommendations": true,
   "files.autoGuessEncoding": true,
   "files.autoSave": "afterDelay",
@@ -104,6 +119,8 @@
     "**/.git": true,
     "**/.DS_Store": true,
     "**/__pycache__": true,
+    "**/.pytest_cache": true,
+    "**/.ruff_cache": true,
     "**/node_modules": true,
     "**/vendor": true,
     "dist": true
@@ -115,17 +132,22 @@
   "files.watcherExclude": {
     "**/.git/objects/**": true,
     "**/.git/subtree-cache/**": true,
+    "**/.pytest_cache/**": true,
     "**/node_modules/*/**": true,
     "**/__pycache__/**": true,
+    "**/.ruff_cache/**": true,
     "**/vendor/**": true
   },
   "git.confirmSync": false,
   "git.fetchOnPull": true,
+  "git.autofetch": true,
+  "git.pruneOnFetch": true,
   "git.inputValidationSubjectLength": 128,
   "git.inputValidationLength": 152,
   "git.mergeEditor": true,
-  "git.pruneOnFetch": true,
   "git.pullBeforeCheckout": true,
+  "git.rebaseWhenSync": true,
+  "git.suggestSmartCommit": false,
   "gitlens.defaultGravatarsStyle": "retro",
   "gitlens.outputLevel": "off",
   "gitlens.plusFeatures.enabled": false,
@@ -157,6 +179,7 @@
   "python.analysis.autoImportCompletions": true,
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.inlayHints.variableTypes": true,
+  "python.terminal.activateEnvironment": false,
   "ruff.lint.run": "onSave",
   "ruff.path": [
     "~/.local/bin/ruff"
@@ -166,6 +189,20 @@
   "security.workspace.trust.enabled": false,
   "security.workspace.trust.untrustedFiles": "open",
   "telemetry.telemetryLevel": "off",
+  "terminal.integrated.defaultProfile.linux": "zsh",
+  "terminal.integrated.enableBell": false,
+  "terminal.integrated.profiles.linux": {
+    "zsh": {
+      "path": "/usr/bin/zsh"
+    },
+    "bash": {
+      "path": "/bin/bash"
+    }
+  },
+  "terminal.integrated.scrollback": 10000,
+  "terminal.integrated.smoothScrolling": true,
+  "terminal.integrated.tabs.location": "left",
+  "terminal.integrated.tabs.showActions": "always",
   "typescript.format.insertSpaceAfterConstructor": true,
   "typescript.locale": "en",
   "typescript.preferences.importModuleSpecifier": "non-relative",
@@ -180,6 +217,7 @@
   "window.title": "${dirty} ${activeEditorMedium}${separator}${rootName}",
   "window.titleBarStyle": "custom",
   "workbench.colorTheme": "Solarized Dark",
+  "workbench.editor.enablePreview": false,
   "workbench.editor.closeOnFileDelete": true,
   "workbench.editor.limit.enabled": true,
   "workbench.editor.limit.perEditorGroup": true,
@@ -192,6 +230,7 @@
   "workbench.startupEditor": "none",
   "workbench.tips.enabled": false,
   "workbench.editor.tabActionCloseVisibility": false,
+  "workbench.tree.indent": 14,
   "editor.guides.bracketPairsHorizontal": true,
   "editor.inlayHints.enabled": "offUnlessPressed",
   "editor.inlayHints.padding": true,


### PR DESCRIPTION
## Summary
- add a GNOME configuration helper that applies curated desktop defaults during setup
- expand the VS Code user settings template with productivity and workflow improvements
- document the GNOME support and add tests covering the new configuration logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69074d532b98832e833eb95ae600c975