### PR TITLE
Add AWS profile auto-selection based on Git account directories

### DIFF
--- a/shell/aliases.sh
+++ b/shell/aliases.sh
@@ -148,3 +148,48 @@ get_prompt_parts() {
 }
 
 export PS1='$(get_prompt_parts)'
+
+_freckles_sync_aws_profile() {
+  local desired status
+  desired=$(freckles_python_quiet "$HOME/.shell/aws_profile.py")
+  status=$?
+  if [ $status -ne 0 ]; then
+    return
+  fi
+
+  if [ -z "$desired" ]; then
+    if [ -n "$FRECKLES_AWS_PROFILE" ]; then
+      unset FRECKLES_AWS_PROFILE
+      unset AWS_PROFILE
+      unset AWS_DEFAULT_PROFILE
+      unset AWS_VAULT
+    fi
+    return
+  fi
+
+  if [ "$desired" != "$FRECKLES_AWS_PROFILE" ]; then
+    export FRECKLES_AWS_PROFILE="$desired"
+    export AWS_PROFILE="$desired"
+    export AWS_DEFAULT_PROFILE="$desired"
+    export AWS_VAULT="$desired"
+  fi
+}
+
+if [ -n "${ZSH_VERSION-}" ]; then
+  typeset -a precmd_functions
+  found=0
+  for fn in "${precmd_functions[@]}"; do
+    if [ "$fn" = "_freckles_sync_aws_profile" ]; then
+      found=1
+      break
+    fi
+  done
+  if [ $found -eq 0 ]; then
+    precmd_functions=("${precmd_functions[@]}" "_freckles_sync_aws_profile")
+  fi
+else
+  case ";$PROMPT_COMMAND;" in
+    *"_freckles_sync_aws_profile"*) ;;
+    *) PROMPT_COMMAND="_freckles_sync_aws_profile${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
+  esac
+fi

--- a/shell/aws_profile.py
+++ b/shell/aws_profile.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Resolve the AWS profile associated with the current working directory."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterable, Optional, Tuple
+
+CONFIG_PATH = Path.home() / ".config" / "freckles" / "accounts.json"
+
+
+def _load_accounts() -> list[dict[str, object]]:
+    if not CONFIG_PATH.exists():
+        return []
+    try:
+        data = json.loads(CONFIG_PATH.read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    accounts = data.get("accounts")
+    if isinstance(accounts, list):
+        return [account for account in accounts if isinstance(account, dict)]
+    return []
+
+
+def _expand_directory(directory: str) -> Path:
+    expanded = os.path.expanduser(directory)
+    try:
+        return Path(expanded).resolve()
+    except OSError:
+        return Path(expanded)
+
+
+def _git_root() -> Optional[Path]:
+    try:
+        output = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    path = output.decode().strip()
+    if not path:
+        return None
+    return Path(path).resolve()
+
+
+def _candidate_paths() -> Iterable[Path]:
+    cwd = Path.cwd()
+    try:
+        cwd = cwd.resolve()
+    except OSError:
+        pass
+    yield cwd
+    root = _git_root()
+    if root:
+        yield root
+
+
+def _matches(base: Path, candidate: Path) -> bool:
+    if base == candidate:
+        return True
+    try:
+        candidate.relative_to(base)
+    except ValueError:
+        return False
+    return True
+
+
+def _determine_profile() -> Optional[str]:
+    accounts = _load_accounts()
+    if not accounts:
+        return None
+
+    candidates = list(_candidate_paths())
+    best_match: Optional[Tuple[int, str]] = None
+
+    for account in accounts:
+        profile = account.get("aws_profile")
+        directory = account.get("directory")
+        if not profile or not isinstance(profile, str):
+            continue
+        if not directory or not isinstance(directory, str):
+            continue
+        base = _expand_directory(directory)
+        base_posix = base.as_posix()
+        for candidate in candidates:
+            if _matches(base, candidate):
+                score = len(base_posix)
+                if not best_match or score > best_match[0]:
+                    best_match = (score, profile)
+                break
+
+    if best_match:
+        return best_match[1]
+    return None
+
+
+def main() -> int:
+    profile = _determine_profile()
+    if profile:
+        print(profile.strip())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/accounts.py
+++ b/utils/accounts.py
@@ -46,6 +46,7 @@ class GitAccount:
     op_vault: Optional[str] = None
     op_item: Optional[str] = None
     ssh_host: Optional[str] = None
+    aws_profile: Optional[str] = None
 
     def __post_init__(self) -> None:
         self.scope = self.scope.strip()
@@ -65,6 +66,8 @@ class GitAccount:
             self.op_item = self.op_item.strip()
         if self.ssh_host:
             self.ssh_host = self.ssh_host.strip()
+        if self.aws_profile:
+            self.aws_profile = self.aws_profile.strip()
 
     @property
     def alias_slug(self) -> str:
@@ -271,6 +274,13 @@ def _prompt_account(existing: Optional[GitAccount] = None) -> GitAccount:
         allow_empty=True,
     )
 
+    aws_profile_default = existing.aws_profile if existing and existing.aws_profile else ""
+    aws_profile = _prompt(
+        "AWS profile name for this identity (leave blank if unused)",
+        default=aws_profile_default,
+        allow_empty=True,
+    )
+
     return GitAccount(
         scope=scope,
         provider=provider,
@@ -283,6 +293,7 @@ def _prompt_account(existing: Optional[GitAccount] = None) -> GitAccount:
         op_vault=op_vault,
         op_item=op_item,
         ssh_host=ssh_host or None,
+        aws_profile=aws_profile or None,
     )
 
 

--- a/utils/git.py
+++ b/utils/git.py
@@ -136,8 +136,9 @@ def _summarise_accounts(config: AccountConfig) -> None:
         f"  default: {config.get_default().display_name} <{config.get_default().email}>",
     ]
     for account in config.accounts:
+        aws_details = f" [aws:{account.aws_profile}]" if account.aws_profile else ""
         message.append(
-            f"  - {account.alias_slug}: {account.provider} ({account.scope}) -> {account.directory}"
+            f"  - {account.alias_slug}: {account.provider} ({account.scope}) -> {account.directory}{aws_details}"
         )
     print("\n".join(message))
 


### PR DESCRIPTION
## Summary
- prompt for an optional AWS profile when configuring git identities
- expose AWS profile information in the git identity summary output
- sync AWS-related environment variables from the shell using a directory-aware resolver

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690750fe21ec832ea81c66ba67471dc2