### PR TITLE
Align GNOME theming with Freckles palette

### DIFF
--- a/tests/test_gnome.py
+++ b/tests/test_gnome.py
@@ -24,6 +24,8 @@ def test_configure_gnome_requires_gsettings(monkeypatch):
 
     monkeypatch.setattr(gnome, "which", lambda _: None)
     monkeypatch.setattr(gnome, "_apply_setting", fake_apply)
+    monkeypatch.setattr(gnome, "_is_setting_supported", lambda *_: False)
+    monkeypatch.setattr(gnome, "is_ubuntu", lambda: False)
 
     gnome.configure_gnome()
 
@@ -39,10 +41,17 @@ def test_configure_gnome_applies_curated_settings(monkeypatch):
 
     monkeypatch.setattr(gnome, "which", lambda _: "/usr/bin/gsettings")
     monkeypatch.setattr(gnome, "_apply_setting", fake_apply)
+    monkeypatch.setattr(gnome, "_is_setting_supported", lambda *_: False)
+    monkeypatch.setattr(gnome, "is_ubuntu", lambda: False)
 
     gnome.configure_gnome()
 
     assert ("org.gnome.desktop.interface", "clock-show-date", "true") in commands
+    assert (
+        "org.gnome.desktop.interface",
+        "gtk-theme",
+        "'Adwaita-dark'",
+    ) in commands
 
     favorite_apps = (
         "org.gnome.shell",
@@ -67,3 +76,47 @@ def test_configure_gnome_applies_curated_settings(monkeypatch):
         "'/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/launch-vscode/']",
     )
     assert custom_list_entry in commands
+
+
+def test_configure_gnome_uses_ubuntu_theme(monkeypatch):
+    commands = []
+
+    def fake_apply(schema: str, key: str, value: str):
+        commands.append((schema, key, value))
+        return FakeProcess()
+
+    monkeypatch.setattr(gnome, "which", lambda _: "/usr/bin/gsettings")
+    monkeypatch.setattr(gnome, "_apply_setting", fake_apply)
+    monkeypatch.setattr(gnome, "_is_setting_supported", lambda *_: False)
+    monkeypatch.setattr(gnome, "is_ubuntu", lambda: True)
+
+    gnome.configure_gnome()
+
+    ubuntu_theme = (
+        "org.gnome.desktop.interface",
+        "gtk-theme",
+        "'Yaru-purple-dark'",
+    )
+    assert ubuntu_theme in commands
+
+
+def test_configure_gnome_applies_optional_settings(monkeypatch):
+    commands = []
+
+    def fake_apply(schema: str, key: str, value: str):
+        commands.append((schema, key, value))
+        return FakeProcess()
+
+    monkeypatch.setattr(gnome, "which", lambda _: "/usr/bin/gsettings")
+    monkeypatch.setattr(gnome, "_apply_setting", fake_apply)
+    monkeypatch.setattr(gnome, "_is_setting_supported", lambda *_: True)
+    monkeypatch.setattr(gnome, "is_ubuntu", lambda: False)
+
+    gnome.configure_gnome()
+
+    accent = (
+        "org.gnome.desktop.interface",
+        "accent-color",
+        "'purple'",
+    )
+    assert accent in commands

--- a/utils/gnome.py
+++ b/utils/gnome.py
@@ -6,13 +6,12 @@ from shutil import which
 from subprocess import CompletedProcess, run
 from typing import Iterable, Sequence
 
-GNOME_SETTINGS: Sequence[tuple[str, str, str]] = (
+from .debian import is_ubuntu
+
+BASE_GNOME_SETTINGS: Sequence[tuple[str, str, str]] = (
     ("org.gnome.desktop.interface", "clock-show-date", "true"),
     ("org.gnome.desktop.interface", "clock-show-weekday", "true"),
     ("org.gnome.desktop.interface", "clock-format", "'24h'"),
-    ("org.gnome.desktop.interface", "cursor-theme", "'Adwaita'"),
-    ("org.gnome.desktop.interface", "gtk-theme", "'Adwaita-dark'"),
-    ("org.gnome.desktop.interface", "icon-theme", "'Adwaita'"),
     ("org.gnome.desktop.interface", "color-scheme", "'prefer-dark'"),
     ("org.gnome.desktop.interface", "enable-hot-corners", "false"),
     (
@@ -48,6 +47,22 @@ GNOME_SETTINGS: Sequence[tuple[str, str, str]] = (
     ("org.gnome.settings-daemon.plugins.power", "sleep-inactive-battery-type", "'suspend'"),
 )
 
+DEFAULT_THEME_SETTINGS: Sequence[tuple[str, str, str]] = (
+    ("org.gnome.desktop.interface", "cursor-theme", "'Adwaita'"),
+    ("org.gnome.desktop.interface", "gtk-theme", "'Adwaita-dark'"),
+    ("org.gnome.desktop.interface", "icon-theme", "'Adwaita'"),
+)
+
+UBUNTU_THEME_SETTINGS: Sequence[tuple[str, str, str]] = (
+    ("org.gnome.desktop.interface", "cursor-theme", "'Yaru'"),
+    ("org.gnome.desktop.interface", "gtk-theme", "'Yaru-purple-dark'"),
+    ("org.gnome.desktop.interface", "icon-theme", "'Yaru-purple'"),
+)
+
+OPTIONAL_SETTINGS: Sequence[tuple[str, str, str]] = (
+    ("org.gnome.desktop.interface", "accent-color", "'purple'"),
+)
+
 CUSTOM_KEYBINDING_SCHEMA = (
     "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding"
 )
@@ -77,10 +92,36 @@ def configure_gnome() -> None:
         # GNOME is not installed or ``gsettings`` is unavailable.
         return
 
-    for schema, key, value in GNOME_SETTINGS:
+    for schema, key, value in _build_settings():
         _apply_setting(schema, key, value)
 
+    for schema, key, value in OPTIONAL_SETTINGS:
+        if _is_setting_supported(schema, key):
+            _apply_setting(schema, key, value)
+
     _configure_custom_keybindings(CUSTOM_KEYBINDINGS)
+
+
+def _build_settings() -> Sequence[tuple[str, str, str]]:
+    """Return the GNOME settings tailored to the detected distribution."""
+
+    theme_settings = UBUNTU_THEME_SETTINGS if is_ubuntu() else DEFAULT_THEME_SETTINGS
+    return (*BASE_GNOME_SETTINGS, *theme_settings)
+
+
+def _is_setting_supported(schema: str, key: str) -> bool:
+    """Return ``True`` when ``schema`` exposes ``key``."""
+
+    result = run(
+        ["gsettings", "describe", schema, key],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+    output = (result.stderr or "") + (result.stdout or "")
+    return "No such key" not in output
 
 
 def _configure_custom_keybindings(bindings: Iterable[dict[str, str]]) -> None:


### PR DESCRIPTION
## Summary
- tailor GNOME configuration to choose the Freckles-friendly Yaru purple theme on Ubuntu while keeping Adwaita defaults elsewhere
- apply the purple accent only when the schema supports it to keep the desktop palette consistent
- extend GNOME configuration tests to cover distro-specific theming and optional settings

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_6909ae6768a0832eb4f36987c1f147f2