### PR TITLE
Refine GNOME theming preferences

### DIFF
--- a/tests/test_gnome.py
+++ b/tests/test_gnome.py
@@ -25,6 +25,7 @@ def test_configure_gnome_requires_gsettings(monkeypatch):
     monkeypatch.setattr(gnome, "which", lambda _: None)
     monkeypatch.setattr(gnome, "_apply_setting", fake_apply)
     monkeypatch.setattr(gnome, "_is_setting_supported", lambda *_: False)
+    monkeypatch.setattr(gnome, "_configure_terminal_theme", lambda: called.append("terminal"))
 
     gnome.configure_gnome()
 
@@ -33,6 +34,7 @@ def test_configure_gnome_requires_gsettings(monkeypatch):
 
 def test_configure_gnome_applies_curated_settings(monkeypatch):
     commands = []
+    terminal_calls = []
 
     def fake_apply(schema: str, key: str, value: str):
         commands.append((schema, key, value))
@@ -44,6 +46,7 @@ def test_configure_gnome_applies_curated_settings(monkeypatch):
     monkeypatch.setattr(gnome, "_preferred_cursor_theme", lambda: "Adwaita")
     monkeypatch.setattr(gnome, "_preferred_gtk_theme", lambda: "Adwaita-dark")
     monkeypatch.setattr(gnome, "_preferred_icon_theme", lambda: "Papirus-Dark")
+    monkeypatch.setattr(gnome, "_configure_terminal_theme", lambda: terminal_calls.append(True))
 
     gnome.configure_gnome()
 
@@ -82,10 +85,12 @@ def test_configure_gnome_applies_curated_settings(monkeypatch):
         "'/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/launch-vscode/']",
     )
     assert custom_list_entry in commands
+    assert terminal_calls == [True]
 
 
 def test_configure_gnome_uses_curated_theme_on_ubuntu(monkeypatch):
     commands = []
+    monkeypatch.setattr(gnome, "_configure_terminal_theme", lambda: None)
 
     def fake_apply(schema: str, key: str, value: str):
         commands.append((schema, key, value))
@@ -110,6 +115,7 @@ def test_configure_gnome_uses_curated_theme_on_ubuntu(monkeypatch):
 
 def test_configure_gnome_applies_optional_settings(monkeypatch):
     commands = []
+    monkeypatch.setattr(gnome, "_configure_terminal_theme", lambda: None)
 
     def fake_apply(schema: str, key: str, value: str):
         commands.append((schema, key, value))
@@ -172,3 +178,46 @@ def test_preferred_cursor_theme_falls_back_to_default(monkeypatch):
     monkeypatch.setattr(gnome, "ICON_SEARCH_PATHS", tuple())
 
     assert gnome._preferred_cursor_theme() == "Adwaita"
+
+
+def test_default_terminal_profile_id_parses_output(monkeypatch):
+    monkeypatch.setattr(
+        gnome,
+        "run",
+        lambda *_, **__: FakeProcess(stdout="'1234-uuid'")
+    )
+
+    assert gnome._default_terminal_profile_id() == "1234-uuid"
+
+
+def test_default_terminal_profile_id_handles_failure(monkeypatch):
+    monkeypatch.setattr(
+        gnome,
+        "run",
+        lambda *_, **__: FakeProcess(returncode=1)
+    )
+
+    assert gnome._default_terminal_profile_id() is None
+
+
+def test_configure_terminal_theme_applies_settings(monkeypatch):
+    commands = []
+
+    monkeypatch.setattr(gnome, "_default_terminal_profile_id", lambda: "profile-id")
+    monkeypatch.setattr(gnome, "_apply_setting", lambda *args: (commands.append(args), FakeProcess())[1])
+
+    gnome._configure_terminal_theme()
+
+    profile_schema = f"{gnome.TERMINAL_PROFILE_SCHEMA}:{gnome.TERMINAL_PROFILES_ROOT}profile-id/"
+    assert (profile_schema, "background-color", "'rgb(24,25,31)'") in commands
+
+    palette_commands = [cmd for cmd in commands if cmd[1] == "palette"]
+    assert len(palette_commands) == 1
+    assert "rgb(46,52,64)" in palette_commands[0][2]
+
+
+def test_configure_terminal_theme_no_profile(monkeypatch):
+    monkeypatch.setattr(gnome, "_default_terminal_profile_id", lambda: None)
+    monkeypatch.setattr(gnome, "_apply_setting", lambda *_, **__: (_ for _ in ()).throw(AssertionError))
+
+    gnome._configure_terminal_theme()

--- a/tests/test_gnome.py
+++ b/tests/test_gnome.py
@@ -25,7 +25,6 @@ def test_configure_gnome_requires_gsettings(monkeypatch):
     monkeypatch.setattr(gnome, "which", lambda _: None)
     monkeypatch.setattr(gnome, "_apply_setting", fake_apply)
     monkeypatch.setattr(gnome, "_is_setting_supported", lambda *_: False)
-    monkeypatch.setattr(gnome, "is_ubuntu", lambda: False)
 
     gnome.configure_gnome()
 
@@ -42,7 +41,9 @@ def test_configure_gnome_applies_curated_settings(monkeypatch):
     monkeypatch.setattr(gnome, "which", lambda _: "/usr/bin/gsettings")
     monkeypatch.setattr(gnome, "_apply_setting", fake_apply)
     monkeypatch.setattr(gnome, "_is_setting_supported", lambda *_: False)
-    monkeypatch.setattr(gnome, "is_ubuntu", lambda: False)
+    monkeypatch.setattr(gnome, "_preferred_cursor_theme", lambda: "Adwaita")
+    monkeypatch.setattr(gnome, "_preferred_gtk_theme", lambda: "Adwaita-dark")
+    monkeypatch.setattr(gnome, "_preferred_icon_theme", lambda: "Papirus-Dark")
 
     gnome.configure_gnome()
 
@@ -51,6 +52,11 @@ def test_configure_gnome_applies_curated_settings(monkeypatch):
         "org.gnome.desktop.interface",
         "gtk-theme",
         "'Adwaita-dark'",
+    ) in commands
+    assert (
+        "org.gnome.desktop.interface",
+        "icon-theme",
+        "'Papirus-Dark'",
     ) in commands
 
     favorite_apps = (
@@ -78,7 +84,7 @@ def test_configure_gnome_applies_curated_settings(monkeypatch):
     assert custom_list_entry in commands
 
 
-def test_configure_gnome_uses_ubuntu_theme(monkeypatch):
+def test_configure_gnome_uses_curated_theme_on_ubuntu(monkeypatch):
     commands = []
 
     def fake_apply(schema: str, key: str, value: str):
@@ -88,14 +94,16 @@ def test_configure_gnome_uses_ubuntu_theme(monkeypatch):
     monkeypatch.setattr(gnome, "which", lambda _: "/usr/bin/gsettings")
     monkeypatch.setattr(gnome, "_apply_setting", fake_apply)
     monkeypatch.setattr(gnome, "_is_setting_supported", lambda *_: False)
-    monkeypatch.setattr(gnome, "is_ubuntu", lambda: True)
+    monkeypatch.setattr(gnome, "_preferred_cursor_theme", lambda: "Adwaita")
+    monkeypatch.setattr(gnome, "_preferred_gtk_theme", lambda: "Adwaita-dark")
+    monkeypatch.setattr(gnome, "_preferred_icon_theme", lambda: "Papirus-Dark")
 
     gnome.configure_gnome()
 
     ubuntu_theme = (
         "org.gnome.desktop.interface",
         "gtk-theme",
-        "'Yaru-purple-dark'",
+        "'Adwaita-dark'",
     )
     assert ubuntu_theme in commands
 
@@ -110,13 +118,57 @@ def test_configure_gnome_applies_optional_settings(monkeypatch):
     monkeypatch.setattr(gnome, "which", lambda _: "/usr/bin/gsettings")
     monkeypatch.setattr(gnome, "_apply_setting", fake_apply)
     monkeypatch.setattr(gnome, "_is_setting_supported", lambda *_: True)
-    monkeypatch.setattr(gnome, "is_ubuntu", lambda: False)
+    monkeypatch.setattr(gnome, "_preferred_cursor_theme", lambda: "Adwaita")
+    monkeypatch.setattr(gnome, "_preferred_gtk_theme", lambda: "Adwaita-dark")
+    monkeypatch.setattr(gnome, "_preferred_icon_theme", lambda: "Papirus-Dark")
 
     gnome.configure_gnome()
 
     accent = (
         "org.gnome.desktop.interface",
         "accent-color",
-        "'purple'",
+        "'blue'",
     )
     assert accent in commands
+
+
+def test_preferred_gtk_theme_prefers_installed_candidate(tmp_path, monkeypatch):
+    theme_dir = tmp_path / "adw-gtk3-dark"
+    theme_dir.mkdir()
+    monkeypatch.setattr(gnome, "THEME_SEARCH_PATHS", (tmp_path,))
+
+    assert gnome._preferred_gtk_theme() == "adw-gtk3-dark"
+
+
+def test_preferred_gtk_theme_falls_back_to_default(monkeypatch):
+    monkeypatch.setattr(gnome, "THEME_SEARCH_PATHS", tuple())
+
+    assert gnome._preferred_gtk_theme() == "Adwaita-dark"
+
+
+def test_preferred_icon_theme_prefers_installed_candidate(tmp_path, monkeypatch):
+    icon_dir = tmp_path / "Papirus-Dark"
+    icon_dir.mkdir()
+    monkeypatch.setattr(gnome, "ICON_SEARCH_PATHS", (tmp_path,))
+
+    assert gnome._preferred_icon_theme() == "Papirus-Dark"
+
+
+def test_preferred_icon_theme_falls_back_to_default(monkeypatch):
+    monkeypatch.setattr(gnome, "ICON_SEARCH_PATHS", tuple())
+
+    assert gnome._preferred_icon_theme() == "Adwaita"
+
+
+def test_preferred_cursor_theme_prefers_installed_candidate(tmp_path, monkeypatch):
+    cursor_dir = tmp_path / "Bibata-Modern-Classic"
+    cursor_dir.mkdir()
+    monkeypatch.setattr(gnome, "ICON_SEARCH_PATHS", (tmp_path,))
+
+    assert gnome._preferred_cursor_theme() == "Bibata-Modern-Classic"
+
+
+def test_preferred_cursor_theme_falls_back_to_default(monkeypatch):
+    monkeypatch.setattr(gnome, "ICON_SEARCH_PATHS", tuple())
+
+    assert gnome._preferred_cursor_theme() == "Adwaita"

--- a/utils/gnome.py
+++ b/utils/gnome.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from shutil import which
 from subprocess import CompletedProcess, run
 from typing import Iterable, Sequence
-
-from .debian import is_ubuntu
 
 BASE_GNOME_SETTINGS: Sequence[tuple[str, str, str]] = (
     ("org.gnome.desktop.interface", "clock-show-date", "true"),
@@ -47,20 +46,37 @@ BASE_GNOME_SETTINGS: Sequence[tuple[str, str, str]] = (
     ("org.gnome.settings-daemon.plugins.power", "sleep-inactive-battery-type", "'suspend'"),
 )
 
-DEFAULT_THEME_SETTINGS: Sequence[tuple[str, str, str]] = (
-    ("org.gnome.desktop.interface", "cursor-theme", "'Adwaita'"),
-    ("org.gnome.desktop.interface", "gtk-theme", "'Adwaita-dark'"),
-    ("org.gnome.desktop.interface", "icon-theme", "'Adwaita'"),
+THEME_SEARCH_PATHS: Sequence[Path] = (
+    Path.home() / ".themes",
+    Path("/usr/local/share/themes"),
+    Path("/usr/share/themes"),
 )
 
-UBUNTU_THEME_SETTINGS: Sequence[tuple[str, str, str]] = (
-    ("org.gnome.desktop.interface", "cursor-theme", "'Yaru'"),
-    ("org.gnome.desktop.interface", "gtk-theme", "'Yaru-purple-dark'"),
-    ("org.gnome.desktop.interface", "icon-theme", "'Yaru-purple'"),
+ICON_SEARCH_PATHS: Sequence[Path] = (
+    Path.home() / ".icons",
+    Path("/usr/local/share/icons"),
+    Path("/usr/share/icons"),
+)
+
+GTK_THEME_CANDIDATES: Sequence[str] = (
+    "adw-gtk3-dark",
+    "Adwaita-dark",
+)
+
+ICON_THEME_CANDIDATES: Sequence[str] = (
+    "Papirus-Dark",
+    "Papirus",
+    "Adwaita",
+)
+
+CURSOR_THEME_CANDIDATES: Sequence[str] = (
+    "Bibata-Modern-Classic",
+    "Bibata-Original-Classic",
+    "Adwaita",
 )
 
 OPTIONAL_SETTINGS: Sequence[tuple[str, str, str]] = (
-    ("org.gnome.desktop.interface", "accent-color", "'purple'"),
+    ("org.gnome.desktop.interface", "accent-color", "'blue'"),
 )
 
 CUSTOM_KEYBINDING_SCHEMA = (
@@ -105,8 +121,55 @@ def configure_gnome() -> None:
 def _build_settings() -> Sequence[tuple[str, str, str]]:
     """Return the GNOME settings tailored to the detected distribution."""
 
-    theme_settings = UBUNTU_THEME_SETTINGS if is_ubuntu() else DEFAULT_THEME_SETTINGS
+    theme_settings = (
+        (
+            "org.gnome.desktop.interface",
+            "cursor-theme",
+            _quote(_preferred_cursor_theme()),
+        ),
+        (
+            "org.gnome.desktop.interface",
+            "gtk-theme",
+            _quote(_preferred_gtk_theme()),
+        ),
+        (
+            "org.gnome.desktop.interface",
+            "icon-theme",
+            _quote(_preferred_icon_theme()),
+        ),
+    )
     return (*BASE_GNOME_SETTINGS, *theme_settings)
+
+
+def _preferred_cursor_theme() -> str:
+    return _select_theme(CURSOR_THEME_CANDIDATES, ICON_SEARCH_PATHS)
+
+
+def _preferred_gtk_theme() -> str:
+    return _select_theme(GTK_THEME_CANDIDATES, THEME_SEARCH_PATHS)
+
+
+def _preferred_icon_theme() -> str:
+    return _select_theme(ICON_THEME_CANDIDATES, ICON_SEARCH_PATHS)
+
+
+def _select_theme(candidates: Sequence[str], search_paths: Sequence[Path]) -> str:
+    if not candidates:
+        return ""
+
+    for theme in candidates[:-1]:
+        if _theme_exists(theme, search_paths):
+            return theme
+
+    return candidates[-1]
+
+
+def _theme_exists(name: str, search_paths: Sequence[Path]) -> bool:
+    return any((path / name).exists() for path in search_paths)
+
+
+def _quote(value: str) -> str:
+    return f"'{value}'"
 
 
 def _is_setting_supported(schema: str, key: str) -> bool:

--- a/utils/gnome.py
+++ b/utils/gnome.py
@@ -79,6 +79,46 @@ OPTIONAL_SETTINGS: Sequence[tuple[str, str, str]] = (
     ("org.gnome.desktop.interface", "accent-color", "'blue'"),
 )
 
+TERMINAL_PROFILE_SCHEMA = "org.gnome.Terminal.Legacy.Profile"
+TERMINAL_PROFILES_ROOT = "/org/gnome/terminal/legacy/profiles:/"
+
+TERMINAL_THEME_SETTINGS: Sequence[tuple[str, str]] = (
+    ("use-theme-colors", "false"),
+    ("use-system-font", "false"),
+    ("font", "'Cascadia Code 11'"),
+    ("background-color", "'rgb(24,25,31)'"),
+    ("foreground-color", "'rgb(216,222,233)'"),
+    ("bold-color", "'rgb(129,161,193)'"),
+    ("bold-color-same-as-fg", "false"),
+    ("cursor-colors-set", "true"),
+    ("cursor-background-color", "'rgb(216,222,233)'"),
+    ("cursor-foreground-color", "'rgb(24,25,31)'"),
+    ("highlight-colors-set", "true"),
+    ("highlight-background-color", "'rgb(67,76,94)'"),
+    ("highlight-foreground-color", "'rgb(236,239,244)'"),
+    ("audible-bell", "false"),
+    ("visible-name", "'Freckles'"),
+)
+
+TERMINAL_THEME_PALETTE: Sequence[str] = (
+    "rgb(46,52,64)",
+    "rgb(191,97,106)",
+    "rgb(163,190,140)",
+    "rgb(235,203,139)",
+    "rgb(129,161,193)",
+    "rgb(180,142,173)",
+    "rgb(136,192,208)",
+    "rgb(236,239,244)",
+    "rgb(76,86,106)",
+    "rgb(208,135,112)",
+    "rgb(163,190,140)",
+    "rgb(235,203,139)",
+    "rgb(129,161,193)",
+    "rgb(180,142,173)",
+    "rgb(143,188,187)",
+    "rgb(236,239,244)",
+)
+
 CUSTOM_KEYBINDING_SCHEMA = (
     "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding"
 )
@@ -115,6 +155,7 @@ def configure_gnome() -> None:
         if _is_setting_supported(schema, key):
             _apply_setting(schema, key, value)
 
+    _configure_terminal_theme()
     _configure_custom_keybindings(CUSTOM_KEYBINDINGS)
 
 
@@ -208,6 +249,41 @@ def _configure_custom_keybindings(bindings: Iterable[dict[str, str]]) -> None:
         _apply_setting(schema, "name", f"'{binding['name']}'")
         _apply_setting(schema, "command", f"'{binding['command']}'")
         _apply_setting(schema, "binding", f"'{binding['binding']}'")
+
+
+def _configure_terminal_theme() -> None:
+    profile_id = _default_terminal_profile_id()
+    if not profile_id:
+        return
+
+    schema = f"{TERMINAL_PROFILE_SCHEMA}:{TERMINAL_PROFILES_ROOT}{profile_id}/"
+
+    for key, value in TERMINAL_THEME_SETTINGS:
+        _apply_setting(schema, key, value)
+
+    palette_literal = _serialize_palette(TERMINAL_THEME_PALETTE)
+    _apply_setting(schema, "palette", palette_literal)
+
+
+def _default_terminal_profile_id() -> str | None:
+    result = run(
+        ["gsettings", "get", "org.gnome.Terminal.ProfilesList", "default"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+
+    output = (result.stdout or result.stderr or "").strip()
+    if not output:
+        return None
+
+    return output.strip("'\"") or None
+
+
+def _serialize_palette(colors: Sequence[str]) -> str:
+    return "[" + ", ".join(f"'{color}'" for color in colors) + "]"
 
 
 def _apply_setting(schema: str, key: str, value: str) -> CompletedProcess[str]:


### PR DESCRIPTION
## Summary
- prefer the curated GNOME theme and icon set instead of Ubuntu defaults
- detect installed GTK, icon, and cursor themes so custom assets win when present
- expand GNOME configuration tests for the new selection helpers

## Testing
- pytest tests/test_gnome.py

------
https://chatgpt.com/codex/tasks/task_e_6909b5995308832e9adead66261ee2eb