### PR TITLE
Unify Freckles theme across desktop and terminal

### DIFF
--- a/tests/test_gnome.py
+++ b/tests/test_gnome.py
@@ -6,6 +6,10 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils import gnome  # noqa: E402
+from utils.theme import (  # noqa: E402
+    FRECKLES_INTERFACE_THEME,
+    FRECKLES_TERMINAL_THEME,
+)
 
 
 class FakeProcess:
@@ -60,6 +64,27 @@ def test_configure_gnome_applies_curated_settings(monkeypatch):
         "org.gnome.desktop.interface",
         "icon-theme",
         "'Papirus-Dark'",
+    ) in commands
+
+    assert (
+        "org.gnome.desktop.interface",
+        "font-name",
+        f"'{FRECKLES_INTERFACE_THEME.interface_font}'",
+    ) in commands
+    assert (
+        "org.gnome.desktop.interface",
+        "document-font-name",
+        f"'{FRECKLES_INTERFACE_THEME.document_font}'",
+    ) in commands
+    assert (
+        "org.gnome.desktop.interface",
+        "monospace-font-name",
+        f"'{FRECKLES_INTERFACE_THEME.monospace_font}'",
+    ) in commands
+    assert (
+        "org.gnome.desktop.wm.preferences",
+        "titlebar-font",
+        f"'{FRECKLES_INTERFACE_THEME.titlebar_font}'",
     ) in commands
 
     favorite_apps = (
@@ -133,7 +158,7 @@ def test_configure_gnome_applies_optional_settings(monkeypatch):
     accent = (
         "org.gnome.desktop.interface",
         "accent-color",
-        "'blue'",
+        f"'{FRECKLES_INTERFACE_THEME.accent}'",
     )
     assert accent in commands
 
@@ -209,11 +234,17 @@ def test_configure_terminal_theme_applies_settings(monkeypatch):
     gnome._configure_terminal_theme()
 
     profile_schema = f"{gnome.TERMINAL_PROFILE_SCHEMA}:{gnome.TERMINAL_PROFILES_ROOT}profile-id/"
-    assert (profile_schema, "background-color", "'rgb(24,25,31)'") in commands
+    assert (
+        profile_schema,
+        "background-color",
+        f"'{FRECKLES_TERMINAL_THEME.background}'",
+    ) in commands
 
     palette_commands = [cmd for cmd in commands if cmd[1] == "palette"]
     assert len(palette_commands) == 1
-    assert "rgb(46,52,64)" in palette_commands[0][2]
+    assert palette_commands[0][2] == gnome._serialize_palette(
+        FRECKLES_TERMINAL_THEME.palette
+    )
 
 
 def test_configure_terminal_theme_no_profile(monkeypatch):

--- a/utils/gnome.py
+++ b/utils/gnome.py
@@ -7,6 +7,8 @@ from shutil import which
 from subprocess import CompletedProcess, run
 from typing import Iterable, Sequence
 
+from .theme import FRECKLES_INTERFACE_THEME, FRECKLES_TERMINAL_THEME
+
 BASE_GNOME_SETTINGS: Sequence[tuple[str, str, str]] = (
     ("org.gnome.desktop.interface", "clock-show-date", "true"),
     ("org.gnome.desktop.interface", "clock-show-weekday", "true"),
@@ -16,7 +18,17 @@ BASE_GNOME_SETTINGS: Sequence[tuple[str, str, str]] = (
     (
         "org.gnome.desktop.interface",
         "monospace-font-name",
-        "'Cascadia Code 11'",
+        f"'{FRECKLES_INTERFACE_THEME.monospace_font}'",
+    ),
+    (
+        "org.gnome.desktop.interface",
+        "font-name",
+        f"'{FRECKLES_INTERFACE_THEME.interface_font}'",
+    ),
+    (
+        "org.gnome.desktop.interface",
+        "document-font-name",
+        f"'{FRECKLES_INTERFACE_THEME.document_font}'",
     ),
     ("org.gnome.desktop.interface", "text-scaling-factor", "1.05"),
     ("org.gnome.desktop.media-handling", "automount", "false"),
@@ -33,6 +45,11 @@ BASE_GNOME_SETTINGS: Sequence[tuple[str, str, str]] = (
     ("org.gnome.desktop.sound", "event-sounds", "false"),
     ("org.gnome.desktop.sound", "allow-volume-above-100-percent", "true"),
     ("org.gnome.desktop.wm.preferences", "button-layout", "'appmenu:minimize,maximize,close'"),
+    (
+        "org.gnome.desktop.wm.preferences",
+        "titlebar-font",
+        f"'{FRECKLES_INTERFACE_THEME.titlebar_font}'",
+    ),
     ("org.gnome.desktop.wm.preferences", "focus-new-windows", "'smart'"),
     ("org.gnome.desktop.wm.preferences", "resize-with-right-button", "true"),
     ("org.gnome.mutter", "center-new-windows", "true"),
@@ -76,7 +93,11 @@ CURSOR_THEME_CANDIDATES: Sequence[str] = (
 )
 
 OPTIONAL_SETTINGS: Sequence[tuple[str, str, str]] = (
-    ("org.gnome.desktop.interface", "accent-color", "'blue'"),
+    (
+        "org.gnome.desktop.interface",
+        "accent-color",
+        f"'{FRECKLES_INTERFACE_THEME.accent}'",
+    ),
 )
 
 TERMINAL_PROFILE_SCHEMA = "org.gnome.Terminal.Legacy.Profile"
@@ -85,39 +106,34 @@ TERMINAL_PROFILES_ROOT = "/org/gnome/terminal/legacy/profiles:/"
 TERMINAL_THEME_SETTINGS: Sequence[tuple[str, str]] = (
     ("use-theme-colors", "false"),
     ("use-system-font", "false"),
-    ("font", "'Cascadia Code 11'"),
-    ("background-color", "'rgb(24,25,31)'"),
-    ("foreground-color", "'rgb(216,222,233)'"),
-    ("bold-color", "'rgb(129,161,193)'"),
+    ("font", f"'{FRECKLES_TERMINAL_THEME.font}'"),
+    ("background-color", f"'{FRECKLES_TERMINAL_THEME.background}'"),
+    ("foreground-color", f"'{FRECKLES_TERMINAL_THEME.foreground}'"),
+    ("bold-color", f"'{FRECKLES_TERMINAL_THEME.bold}'"),
     ("bold-color-same-as-fg", "false"),
     ("cursor-colors-set", "true"),
-    ("cursor-background-color", "'rgb(216,222,233)'"),
-    ("cursor-foreground-color", "'rgb(24,25,31)'"),
+    (
+        "cursor-background-color",
+        f"'{FRECKLES_TERMINAL_THEME.cursor_background}'",
+    ),
+    (
+        "cursor-foreground-color",
+        f"'{FRECKLES_TERMINAL_THEME.cursor_foreground}'",
+    ),
     ("highlight-colors-set", "true"),
-    ("highlight-background-color", "'rgb(67,76,94)'"),
-    ("highlight-foreground-color", "'rgb(236,239,244)'"),
+    (
+        "highlight-background-color",
+        f"'{FRECKLES_TERMINAL_THEME.highlight_background}'",
+    ),
+    (
+        "highlight-foreground-color",
+        f"'{FRECKLES_TERMINAL_THEME.highlight_foreground}'",
+    ),
     ("audible-bell", "false"),
-    ("visible-name", "'Freckles'"),
+    ("visible-name", f"'{FRECKLES_TERMINAL_THEME.name}'"),
 )
 
-TERMINAL_THEME_PALETTE: Sequence[str] = (
-    "rgb(46,52,64)",
-    "rgb(191,97,106)",
-    "rgb(163,190,140)",
-    "rgb(235,203,139)",
-    "rgb(129,161,193)",
-    "rgb(180,142,173)",
-    "rgb(136,192,208)",
-    "rgb(236,239,244)",
-    "rgb(76,86,106)",
-    "rgb(208,135,112)",
-    "rgb(163,190,140)",
-    "rgb(235,203,139)",
-    "rgb(129,161,193)",
-    "rgb(180,142,173)",
-    "rgb(143,188,187)",
-    "rgb(236,239,244)",
-)
+TERMINAL_THEME_PALETTE: Sequence[str] = FRECKLES_TERMINAL_THEME.palette
 
 CUSTOM_KEYBINDING_SCHEMA = (
     "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding"

--- a/utils/terminal.py
+++ b/utils/terminal.py
@@ -5,50 +5,34 @@ from __future__ import annotations
 from shutil import which
 from subprocess import CompletedProcess, run
 
-
-TERMINAL_PALETTE: tuple[str, ...] = (
-    "rgb(23, 23, 27)",
-    "rgb(230, 130, 130)",
-    "rgb(104, 201, 129)",
-    "rgb(246, 202, 113)",
-    "rgb(125, 178, 255)",
-    "rgb(172, 129, 255)",
-    "rgb(97, 212, 214)",
-    "rgb(234, 232, 252)",
-    "rgb(70, 74, 85)",
-    "rgb(255, 151, 151)",
-    "rgb(125, 222, 149)",
-    "rgb(255, 213, 128)",
-    "rgb(146, 189, 255)",
-    "rgb(194, 160, 255)",
-    "rgb(128, 226, 228)",
-    "rgb(247, 247, 252)",
-)
+from .theme import FRECKLES_TERMINAL_THEME
 
 PROFILE_SETTINGS: dict[str, str] = {
     "audible-bell": "false",
-    "background-color": "'rgb(13, 16, 24)'",
+    "background-color": f"'{FRECKLES_TERMINAL_THEME.background}'",
     "background-transparency-percent": "0",
-    "bold-color": "'rgb(157, 179, 255)'",
+    "bold-color": f"'{FRECKLES_TERMINAL_THEME.bold}'",
     "bold-color-same-as-fg": "false",
-    "cursor-background-color": "'rgb(255, 210, 111)'",
+    "cursor-background-color": f"'{FRECKLES_TERMINAL_THEME.cursor_background}'",
     "cursor-colors-set": "true",
-    "cursor-foreground-color": "'rgb(13, 16, 24)'",
+    "cursor-foreground-color": f"'{FRECKLES_TERMINAL_THEME.cursor_foreground}'",
     "cursor-shape": "'block'",
     "default-size-columns": "120",
     "default-size-rows": "34",
-    "font": "'Cascadia Code 12'",
-    "foreground-color": "'rgb(234, 232, 252)'",
-    "highlight-background-color": "'rgb(62, 70, 90)'",
+    "font": f"'{FRECKLES_TERMINAL_THEME.font}'",
+    "foreground-color": f"'{FRECKLES_TERMINAL_THEME.foreground}'",
+    "highlight-background-color": f"'{FRECKLES_TERMINAL_THEME.highlight_background}'",
     "highlight-colors-set": "true",
-    "highlight-foreground-color": "'rgb(245, 245, 250)'",
+    "highlight-foreground-color": f"'{FRECKLES_TERMINAL_THEME.highlight_foreground}'",
     "login-shell": "true",
-    "palette": "[" + ", ".join(f"'{colour}'" for colour in TERMINAL_PALETTE) + "]",
+    "palette": "["
+    + ", ".join(f"'{colour}'" for colour in FRECKLES_TERMINAL_THEME.palette)
+    + "]",
     "scrollbar-policy": "'never'",
     "use-custom-default-size": "true",
     "use-system-font": "false",
     "use-theme-colors": "false",
-    "visible-name": "'Freckles Midnight'",
+    "visible-name": f"'{FRECKLES_TERMINAL_THEME.name}'",
 }
 
 

--- a/utils/theme.py
+++ b/utils/theme.py
@@ -1,0 +1,79 @@
+"""Shared Freckles theming primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class InterfaceTheme:
+    """Fonts and accents applied across the GNOME desktop."""
+
+    accent: str
+    interface_font: str
+    document_font: str
+    monospace_font: str
+    titlebar_font: str
+
+
+@dataclass(frozen=True)
+class TerminalTheme:
+    """Colour palette and typography for terminal profiles."""
+
+    name: str
+    font: str
+    background: str
+    foreground: str
+    bold: str
+    cursor_background: str
+    cursor_foreground: str
+    highlight_background: str
+    highlight_foreground: str
+    palette: tuple[str, ...]
+
+
+FRECKLES_INTERFACE_THEME = InterfaceTheme(
+    accent="blue",
+    interface_font="Cantarell 11",
+    document_font="Cantarell 11",
+    monospace_font="Cascadia Code 11",
+    titlebar_font="Cantarell Bold 11",
+)
+
+FRECKLES_TERMINAL_THEME = TerminalTheme(
+    name="Freckles Midnight",
+    font="Cascadia Code 12",
+    background="rgb(13, 16, 24)",
+    foreground="rgb(234, 232, 252)",
+    bold="rgb(157, 179, 255)",
+    cursor_background="rgb(255, 210, 111)",
+    cursor_foreground="rgb(13, 16, 24)",
+    highlight_background="rgb(62, 70, 90)",
+    highlight_foreground="rgb(245, 245, 250)",
+    palette=(
+        "rgb(23, 23, 27)",
+        "rgb(230, 130, 130)",
+        "rgb(104, 201, 129)",
+        "rgb(246, 202, 113)",
+        "rgb(125, 178, 255)",
+        "rgb(172, 129, 255)",
+        "rgb(97, 212, 214)",
+        "rgb(234, 232, 252)",
+        "rgb(70, 74, 85)",
+        "rgb(255, 151, 151)",
+        "rgb(125, 222, 149)",
+        "rgb(255, 213, 128)",
+        "rgb(146, 189, 255)",
+        "rgb(194, 160, 255)",
+        "rgb(128, 226, 228)",
+        "rgb(247, 247, 252)",
+    ),
+)
+
+
+__all__ = [
+    "FRECKLES_INTERFACE_THEME",
+    "FRECKLES_TERMINAL_THEME",
+    "InterfaceTheme",
+    "TerminalTheme",
+]


### PR DESCRIPTION
## Summary
- add a shared Freckles theme module that defines interface fonts, accent colours, and the terminal palette
- update GNOME configuration to use the shared theme for fonts, accent colour, and terminal profile settings
- align the dedicated terminal synchronisation routine and tests with the shared palette

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6909c44c1ff4832e8ae9756ca3de8f17