### PR TITLE
Use headless Firefox extension installation

### DIFF
--- a/tests/test_firefox.py
+++ b/tests/test_firefox.py
@@ -1,0 +1,105 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from utils import firefox
+
+
+class _FakeCompletedProcess:
+    def __init__(self, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = 0
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+@pytest.fixture(autouse=True)
+def _temp_working_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _prepare_download(tmp_path: Path, file_name: str) -> Path:
+    destination = tmp_path / file_name
+    destination.write_bytes(b"addon-bytes")
+    return destination
+
+
+def test_install_firefox_extension_uses_headless_mode(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_download(url, file_name, **_):
+        assert url.endswith("latest.xpi")
+        return _prepare_download(tmp_path, file_name)
+
+    profile_dir = tmp_path / "profile.default"
+    profile_dir.mkdir()
+
+    def fake_find_profile():
+        return profile_dir.as_posix()
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return _FakeCompletedProcess(stdout="ok")
+
+    monkeypatch.setattr(firefox, "download_file", fake_download)
+    monkeypatch.setattr(firefox, "find_firefox_profile", fake_find_profile)
+    monkeypatch.setattr(firefox.subprocess, "run", fake_run)
+
+    result = firefox.install_firefox_extension("ublock-origin")
+
+    assert result is True
+    assert not (tmp_path / "ublock-origin.xpi").exists()
+    assert calls, "Expected Firefox to be invoked in headless mode"
+    command, kwargs = calls[0]
+    assert command[:4] == ["firefox", "--headless", "--no-remote", "--profile"]
+    assert command[4] == profile_dir.as_posix()
+    assert command[5] == "--install-addon"
+    assert command[6] == (tmp_path / "ublock-origin.xpi").as_posix()
+    assert kwargs["check"] is True
+    assert kwargs["stdout"] is subprocess.PIPE
+    assert kwargs["stderr"] is subprocess.PIPE
+    assert kwargs["text"] is True
+
+
+def test_install_firefox_extension_logs_failure(monkeypatch, tmp_path, capsys):
+    def fake_download(url, file_name, **_):
+        return _prepare_download(tmp_path, file_name)
+
+    profile_dir = tmp_path / "profile.default"
+    profile_dir.mkdir()
+
+    monkeypatch.setattr(firefox, "download_file", fake_download)
+    monkeypatch.setattr(firefox, "find_firefox_profile", lambda: profile_dir.as_posix())
+
+    def fake_run(command, **kwargs):
+        raise subprocess.CalledProcessError(1, command, stderr="boom")
+
+    monkeypatch.setattr(firefox.subprocess, "run", fake_run)
+
+    result = firefox.install_firefox_extension("vimium-ff")
+
+    assert result is False
+    assert not (tmp_path / "vimium-ff.xpi").exists()
+    captured = capsys.readouterr()
+    assert "Error installing extension vimium-ff: boom" in captured.out
+
+
+def test_install_firefox_extension_without_profile(monkeypatch, tmp_path, capsys):
+    def fake_download(url, file_name, **_):
+        return _prepare_download(tmp_path, file_name)
+
+    monkeypatch.setattr(firefox, "download_file", fake_download)
+    monkeypatch.setattr(firefox, "find_firefox_profile", lambda: None)
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("Firefox should not be invoked when no profile exists")
+
+    monkeypatch.setattr(firefox.subprocess, "run", fail_run)
+
+    result = firefox.install_firefox_extension("decentraleyes")
+
+    assert result is False
+    assert not (tmp_path / "decentraleyes.xpi").exists()
+    captured = capsys.readouterr()
+    assert "Firefox profile not found" in captured.out

--- a/utils/firefox.py
+++ b/utils/firefox.py
@@ -222,10 +222,53 @@ def get_extension_json(profile_dir):
 
 
 def install_firefox_extension(extension_id):
+    url = (
+        "https://addons.mozilla.org/firefox/downloads/latest/"
+        f"{extension_id}/addon-{extension_id}-latest.xpi"
+    )
+    xpi_path = None
+
     try:
-        url = f"https://addons.mozilla.org/firefox/downloads/latest/{extension_id}/addon-{extension_id}-latest.xpi"
-        download_file(url, extension_id + ".xpi", overwrite=True)
-        subprocess.run(["firefox", extension_id + ".xpi"], check=True)
+        xpi_path = download_file(url, extension_id + ".xpi", overwrite=True)
+    except Exception as error:  # pragma: no cover - network failures depend on environment
+        print(f"Failed to download extension {extension_id}: {error}")
+        return False
+
+    try:
+        profile_dir = find_firefox_profile()
+        if profile_dir is None:
+            print(
+                "Unable to install Firefox extension "
+                f"{extension_id}: Firefox profile not found."
+            )
+            return False
+
+        install_command = [
+            "firefox",
+            "--headless",
+            "--no-remote",
+            "--profile",
+            profile_dir,
+            "--install-addon",
+            xpi_path.as_posix(),
+        ]
+
+        subprocess.run(
+            install_command,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
         print(f"Extension {extension_id} installed.")
-    except subprocess.CalledProcessError as e:
-        print(f"Error installing extension {extension_id}: {e}")
+        return True
+    except subprocess.CalledProcessError as error:
+        error_output = (error.stderr or error.stdout or str(error)).strip()
+        print(f"Error installing extension {extension_id}: {error_output}")
+        return False
+    except Exception as error:
+        print(f"Unexpected error installing extension {extension_id}: {error}")
+        return False
+    finally:
+        if xpi_path is not None:
+            xpi_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- install Firefox extensions using headless mode with profile detection and temporary download cleanup
- add error logging for download and installation failures
- cover success, failure, and missing profile flows with integration-style tests

## Testing
- PYTHONPATH=. pytest tests/test_firefox.py

------
https://chatgpt.com/codex/tasks/task_e_6909dfd213c0832e826d8b9047b4e2bd