### PR TITLE
Add Calibre to base package installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ core_packages = [
     "curl",
     "fonts-cascadia-code",
     "git",
+    "calibre",
     "gnupg",
     "lsb-release",
     "make",


### PR DESCRIPTION
## Summary
- include Calibre in the list of core packages installed via apt so it is provisioned alongside other essentials

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6909e51d0470832ea128e999ae6f8cb1