### PR TITLE
Refactor setup workflow with structured step reporter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 import re
 import sys
+from contextlib import contextmanager
 
 from utils.avatar import manage_avatar
 from utils.calibre import configure_calibre
-
 from utils.debian import (
     DebFile,
     DebRepository,
@@ -32,6 +32,7 @@ from utils.firefox import (
 )
 from utils.git import configure_git
 from utils.gnome import configure_gnome
+from utils.reporter import StepReporter
 from utils.shell import configure_shell
 from utils.terminal import configure_terminal
 from utils.ssh import configure_ssh
@@ -43,9 +44,6 @@ from utils.web import (
 )
 from utils.ubuntu import ensure_firefox_from_apt, purge_snapd
 
-
-if not is_debian_like():
-    sys.exit("Freckles currently supports Debian and Ubuntu systems only.")
 
 software_list = [
     DebFile(
@@ -95,23 +93,6 @@ unwanted_software = [
     "cups-*",
 ]
 
-apt_update_result = run("sudo apt-get update -yqq")
-if apt_update_result.returncode != 0:
-    combined_output = (apt_update_result.stderr or "") + (apt_update_result.stdout or "")
-    if "NO_PUBKEY" in combined_output:
-        missing_key_ids = {
-            match.group(1).upper()
-            for match in re.finditer(r"NO_PUBKEY\\s+([0-9A-F]+)", combined_output)
-        }
-        refreshed = refresh_repository_keys(software_list, missing_key_ids)
-        if not refreshed:
-            ensure_repositories_configured(software_list)
-        apt_update_result = run("sudo apt-get update -yqq")
-
-if apt_update_result.returncode != 0:
-    message = (apt_update_result.stderr or "").strip() or (apt_update_result.stdout or "").strip()
-    sys.exit(f"Failed to refresh apt package lists: {message}")
-
 core_packages = [
     "ca-certificates",
     "curl",
@@ -124,50 +105,223 @@ core_packages = [
     "zsh",
 ]
 
-essential_install = install_with_apt(core_packages)
-if essential_install.returncode != 0:
-    message = essential_install.stderr.strip() or essential_install.stdout.strip()
-    sys.exit(f"Failed to install required base packages: {message}")
 
-if is_ubuntu():
-    purge_snapd()
+@contextmanager
+def managed_step(reporter: StepReporter, name: str):
+    reporter.start_step(name)
+    try:
+        yield
+    except Exception as exc:  # pragma: no cover - propagation for summary
+        reporter.fail_step(name, exc)
+        raise
+    else:
+        reporter.finish_step(name)
 
-purge_unwanted_packages(unwanted_software)
-install_software_list(software_list)
-configure_vscode()
-configure_git()
-configure_ssh()
-configure_shell()
-configure_terminal()
-configure_gnome()
-manage_avatar()
-configure_calibre()
-if is_debian_12_bookworm() is True:
-    replace_bookworm_with_trixie()
-    run_apt_update_and_upgrade()
-    purge_unwanted_packages(unwanted_software)
-if is_firefox_esr_installed():
-    print("Firefox ESR detected. Purging and installing regular Firefox.")
-    purge_firefox_esr()
-    setup_mozilla_repo()
-    install_regular_firefox()
-    purge_esr_profiles()
-elif is_ubuntu():
-    ensure_firefox_from_apt()
 
-apply_firefox_policies()
+def refresh_apt_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Run apt-get update"):
+        apt_update_result = run("sudo apt-get update -yqq")
+        if apt_update_result.returncode != 0:
+            combined_output = (apt_update_result.stderr or "") + (apt_update_result.stdout or "")
+            if "NO_PUBKEY" in combined_output:
+                missing_key_ids = {
+                    match.group(1).upper()
+                    for match in re.finditer(r"NO_PUBKEY\\s+([0-9A-F]+)", combined_output)
+                }
 
-profile = find_firefox_profile()
-if profile is None:
-    print(
-        "Skipping Firefox profile customization and extension installation because "
-        "no profile was found. Launch Firefox once to create a profile and rerun "
-        "this step if needed."
-    )
-else:
-    apply_firefox_user_js(profile)
-    extension_data = get_extension_json(profile)
-    for extension_id, extension_name in EXTENSIONS_TO_INSTALL.items():
-        if extension_already_installed(extension_data, extension_name):
-            continue
-        install_firefox_extension(extension_id)
+                def refresh_keys() -> None:
+                    reporter.log(
+                        f"Refreshing repository keys for: {', '.join(sorted(missing_key_ids)) or 'unknown keys'}"
+                    )
+                    refreshed = refresh_repository_keys(software_list, missing_key_ids)
+                    if not refreshed:
+                        ensure_repositories_configured(software_list)
+
+                with managed_step(reporter, "Refresh repository keys"):
+                    refresh_keys()
+
+                apt_update_result = run("sudo apt-get update -yqq")
+
+            if apt_update_result.returncode != 0:
+                message = (apt_update_result.stderr or "").strip() or (apt_update_result.stdout or "").strip()
+                raise RuntimeError(f"Failed to refresh apt package lists: {message}")
+
+
+def install_base_packages_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Install required base packages"):
+        essential_install = install_with_apt(core_packages)
+        if essential_install.returncode != 0:
+            message = essential_install.stderr.strip() or essential_install.stdout.strip()
+            raise RuntimeError(f"Failed to install required base packages: {message}")
+
+
+def ubuntu_cleanup_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Ubuntu-specific cleanup"):
+        if not is_ubuntu():
+            reporter.log("Skipping because system is not Ubuntu.")
+            return
+        with managed_step(reporter, "Purge snapd"):
+            purge_snapd()
+
+
+def remove_unwanted_packages_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Remove unwanted packages"):
+        purge_unwanted_packages(unwanted_software)
+
+
+def install_curated_software_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Install curated software"):
+        install_software_list(software_list)
+
+
+def configure_developer_tooling_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Configure developer tooling"):
+        with managed_step(reporter, "Configure VS Code"):
+            configure_vscode()
+        with managed_step(reporter, "Configure Git"):
+            configure_git()
+        with managed_step(reporter, "Configure SSH"):
+            configure_ssh()
+
+
+def configure_shell_terminal_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Configure shell and terminal"):
+        with managed_step(reporter, "Configure shell"):
+            configure_shell()
+        with managed_step(reporter, "Configure terminal"):
+            configure_terminal()
+
+
+def configure_gnome_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Configure GNOME desktop"):
+        configure_gnome()
+
+
+def manage_avatar_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Manage avatar"):
+        manage_avatar()
+
+
+def configure_calibre_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Configure Calibre"):
+        configure_calibre()
+
+
+def upgrade_bookworm_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Handle Debian bookworm upgrade"):
+        if is_debian_12_bookworm() is not True:
+            reporter.log("Skipping because system is not Debian 12 (bookworm).")
+            return
+        with managed_step(reporter, "Switch repositories to trixie"):
+            replace_bookworm_with_trixie()
+        with managed_step(reporter, "Upgrade system packages"):
+            run_apt_update_and_upgrade()
+        with managed_step(reporter, "Re-purge unwanted packages"):
+            purge_unwanted_packages(unwanted_software)
+
+
+def configure_firefox_phase(reporter: StepReporter) -> None:
+    with managed_step(reporter, "Configure Firefox"):
+        with managed_step(reporter, "Ensure correct Firefox variant"):
+            if is_firefox_esr_installed():
+                reporter.log("Firefox ESR detected. Purging and installing regular Firefox.")
+                with managed_step(reporter, "Purge Firefox ESR"):
+                    purge_firefox_esr()
+                with managed_step(reporter, "Configure Mozilla repository"):
+                    setup_mozilla_repo()
+                with managed_step(reporter, "Install regular Firefox"):
+                    install_regular_firefox()
+                with managed_step(reporter, "Remove ESR profiles"):
+                    purge_esr_profiles()
+            elif is_ubuntu():
+                with managed_step(reporter, "Ensure Firefox from APT"):
+                    ensure_firefox_from_apt()
+            else:
+                reporter.log("Firefox ESR not detected; no variant changes required.")
+
+        with managed_step(reporter, "Apply Firefox policies"):
+            apply_firefox_policies()
+
+        with managed_step(reporter, "Customize Firefox profile"):
+            profile = find_firefox_profile()
+            if profile is None:
+                reporter.log(
+                    "Skipping Firefox profile customization and extension installation because no profile was found."
+                )
+                reporter.log("Launch Firefox once to create a profile and rerun this phase if needed.")
+                return
+            with managed_step(reporter, "Apply user.js preferences"):
+                apply_firefox_user_js(profile)
+            extension_data = get_extension_json(profile)
+            with managed_step(reporter, "Install Firefox extensions"):
+                for extension_id, extension_name in EXTENSIONS_TO_INSTALL.items():
+                    if extension_already_installed(extension_data, extension_name):
+                        reporter.log(f"Extension '{extension_name}' already installed. Skipping.")
+                        continue
+                    with managed_step(reporter, f"Install extension: {extension_name}"):
+                        install_firefox_extension(extension_id)
+
+
+def main() -> None:
+    if not is_debian_like():
+        sys.exit("Freckles currently supports Debian and Ubuntu systems only.")
+
+    phases = [
+        ("APT refresh", refresh_apt_phase),
+        ("Base packages", install_base_packages_phase),
+        ("Ubuntu cleanup", ubuntu_cleanup_phase),
+        ("Remove stock software", remove_unwanted_packages_phase),
+        ("Curated software", install_curated_software_phase),
+        ("Developer tooling", configure_developer_tooling_phase),
+        ("Shell and terminal", configure_shell_terminal_phase),
+        ("GNOME setup", configure_gnome_phase),
+        ("Avatar management", manage_avatar_phase),
+        ("Calibre setup", configure_calibre_phase),
+        ("Debian bookworm upgrade", upgrade_bookworm_phase),
+        ("Firefox configuration", configure_firefox_phase),
+    ]
+
+    with StepReporter() as reporter:
+        for label, phase in phases:
+            with managed_step(reporter, label):
+                phase(reporter)
+        summary = reporter.summary()
+
+    children_by_parent = {}
+    for bucket in ("succeeded", "failed"):
+        for entry in summary[bucket]:
+            parent = entry.get("parent")
+            children_by_parent.setdefault(parent, []).append(entry)
+
+    def failed_descendants(parent_name: str):
+        collected = []
+        for child in children_by_parent.get(parent_name, []):
+            if child.get("status") == "failed":
+                collected.append(child)
+            collected.extend(failed_descendants(child["name"]))
+        return collected
+
+    top_level_success = [entry for entry in summary["succeeded"] if entry.get("depth") == 0]
+    top_level_failures = [entry for entry in summary["failed"] if entry.get("depth") == 0]
+
+    print("\n=== Setup Summary ===")
+    if top_level_success:
+        print("Successful phases:")
+        for entry in top_level_success:
+            print(f"  - {entry['name']}")
+    if top_level_failures:
+        print("Failed phases:")
+        for entry in top_level_failures:
+            error = entry.get("error", "Unknown error")
+            print(f"  - {entry['name']}: {error}")
+            nested_failures = failed_descendants(entry["name"])
+            for nested in nested_failures:
+                nested_error = nested.get("error", "Unknown error")
+                print(f"    * {nested['name']}: {nested_error}")
+            print("    Fix the issue and rerun `python setup.py` to retry this phase.")
+    else:
+        print("All phases completed successfully. You're good to go!")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import re
 import sys
 from contextlib import contextmanager
+from typing import Dict, List, Optional
 
 from utils.avatar import manage_avatar
 from utils.calibre import configure_calibre
@@ -116,6 +117,43 @@ def managed_step(reporter: StepReporter, name: str):
         raise
     else:
         reporter.finish_step(name)
+
+
+def emit_summary(summary: Dict[str, List[Dict[str, Optional[str]]]]) -> None:
+    children_by_parent: Dict[Optional[str], List[Dict[str, Optional[str]]]] = {}
+    for bucket in ("succeeded", "failed"):
+        for entry in summary[bucket]:
+            parent = entry.get("parent")
+            children_by_parent.setdefault(parent, []).append(entry)
+
+    def failed_descendants(parent_name: str) -> List[Dict[str, Optional[str]]]:
+        collected: List[Dict[str, Optional[str]]] = []
+        for child in children_by_parent.get(parent_name, []):
+            if child.get("status") == "failed":
+                collected.append(child)
+            collected.extend(failed_descendants(child["name"]))
+        return collected
+
+    top_level_success = [entry for entry in summary["succeeded"] if entry.get("depth") == 0]
+    top_level_failures = [entry for entry in summary["failed"] if entry.get("depth") == 0]
+
+    print("\n=== Setup Summary ===")
+    if top_level_success:
+        print("Successful phases:")
+        for entry in top_level_success:
+            print(f"  - {entry['name']}")
+    if top_level_failures:
+        print("Failed phases:")
+        for entry in top_level_failures:
+            error = entry.get("error", "Unknown error")
+            print(f"  - {entry['name']}: {error}")
+            nested_failures = failed_descendants(entry["name"])
+            for nested in nested_failures:
+                nested_error = nested.get("error", "Unknown error")
+                print(f"    * {nested['name']}: {nested_error}")
+            print("    Fix the issue and rerun `python setup.py` to retry this phase.")
+    else:
+        print("All phases completed successfully. You're good to go!")
 
 
 def refresh_apt_phase(reporter: StepReporter) -> None:
@@ -281,46 +319,17 @@ def main() -> None:
         ("Firefox configuration", configure_firefox_phase),
     ]
 
-    with StepReporter() as reporter:
-        for label, phase in phases:
-            with managed_step(reporter, label):
-                phase(reporter)
-        summary = reporter.summary()
-
-    children_by_parent = {}
-    for bucket in ("succeeded", "failed"):
-        for entry in summary[bucket]:
-            parent = entry.get("parent")
-            children_by_parent.setdefault(parent, []).append(entry)
-
-    def failed_descendants(parent_name: str):
-        collected = []
-        for child in children_by_parent.get(parent_name, []):
-            if child.get("status") == "failed":
-                collected.append(child)
-            collected.extend(failed_descendants(child["name"]))
-        return collected
-
-    top_level_success = [entry for entry in summary["succeeded"] if entry.get("depth") == 0]
-    top_level_failures = [entry for entry in summary["failed"] if entry.get("depth") == 0]
-
-    print("\n=== Setup Summary ===")
-    if top_level_success:
-        print("Successful phases:")
-        for entry in top_level_success:
-            print(f"  - {entry['name']}")
-    if top_level_failures:
-        print("Failed phases:")
-        for entry in top_level_failures:
-            error = entry.get("error", "Unknown error")
-            print(f"  - {entry['name']}: {error}")
-            nested_failures = failed_descendants(entry["name"])
-            for nested in nested_failures:
-                nested_error = nested.get("error", "Unknown error")
-                print(f"    * {nested['name']}: {nested_error}")
-            print("    Fix the issue and rerun `python setup.py` to retry this phase.")
+    reporter = StepReporter()
+    try:
+        with reporter:
+            for label, phase in phases:
+                with managed_step(reporter, label):
+                    phase(reporter)
+    except Exception:
+        emit_summary(reporter.summary())
+        raise
     else:
-        print("All phases completed successfully. You're good to go!")
+        emit_summary(reporter.summary())
 
 
 if __name__ == "__main__":

--- a/utils/reporter.py
+++ b/utils/reporter.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Dict, List, Optional
+
+
+class StepStatus(str, Enum):
+    PENDING = "pending"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+@dataclass
+class Step:
+    name: str
+    parent: Optional["Step"] = None
+    status: StepStatus = StepStatus.PENDING
+    error: Optional[str] = None
+    children: List["Step"] = field(default_factory=list)
+    depth: int = 0
+
+    def as_dict(self) -> Dict[str, Optional[str]]:
+        payload: Dict[str, Optional[str]] = {
+            "name": self.name,
+            "status": self.status.value,
+            "depth": self.depth,
+            "parent": self.parent.name if self.parent else None,
+        }
+        if self.error:
+            payload["error"] = self.error
+        return payload
+
+
+class StepReporter:
+    """Collects hierarchical step information and renders progress messages."""
+
+    def __init__(self, printer: Callable[[str], None] | None = None) -> None:
+        self._print = printer or print
+        self._root = Step(name="__root__", depth=-1)
+        self._stack: List[Step] = [self._root]
+
+    def __enter__(self) -> "StepReporter":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if exc_type is not None:
+            message = str(exc)
+            while len(self._stack) > 1:
+                step = self._stack.pop()
+                if step.status is StepStatus.PENDING:
+                    step.status = StepStatus.FAILED
+                    step.error = message
+        return False
+
+    # Public API ---------------------------------------------------------
+    def start_step(self, name: str) -> None:
+        parent = self._stack[-1]
+        step = Step(name=name, parent=parent, depth=len(self._stack) - 1)
+        parent.children.append(step)
+        self._stack.append(step)
+        self._print(f"{'  ' * step.depth}▶ {name}")
+
+    def finish_step(self, name: str) -> None:
+        step = self._end_step(name)
+        if step.status is StepStatus.FAILED:
+            return
+        step.status = StepStatus.SUCCESS
+        self._print(f"{'  ' * step.depth}✔ {name}")
+
+    def fail_step(self, name: str, error: Exception | str) -> None:
+        step = self._end_step(name)
+        step.status = StepStatus.FAILED
+        step.error = str(error)
+        self._print(f"{'  ' * step.depth}✖ {name}: {step.error}")
+
+    def log(self, message: str) -> None:
+        indent_level = max(len(self._stack) - 2, 0)
+        self._print(f"{'  ' * indent_level}- {message}")
+
+    def summary(self) -> Dict[str, List[Dict[str, Optional[str]]]]:
+        succeeded: List[Dict[str, Optional[str]]] = []
+        failed: List[Dict[str, Optional[str]]] = []
+
+        def visit(step: Step) -> None:
+            for child in step.children:
+                if child.status is StepStatus.SUCCESS:
+                    succeeded.append(child.as_dict())
+                elif child.status is StepStatus.FAILED:
+                    failed.append(child.as_dict())
+                visit(child)
+
+        visit(self._root)
+        return {"succeeded": succeeded, "failed": failed}
+
+    # Internal helpers ---------------------------------------------------
+    def _end_step(self, name: str) -> Step:
+        if len(self._stack) <= 1:
+            raise RuntimeError("Cannot finish a step when no steps are active.")
+        step = self._stack.pop()
+        if step.name != name:
+            self._stack.append(step)
+            raise ValueError(f"Attempted to finish step '{name}' but current step is '{step.name}'.")
+        return step


### PR DESCRIPTION
## Summary
- add a reusable `StepReporter` context manager for hierarchical step tracking and summaries
- refactor `setup.py` to execute ordered setup phases through the reporter with nested sub-steps
- emit a concise recap highlighting successful and failed phases with retry guidance

## Testing
- python -m compileall setup.py utils/reporter.py

------
https://chatgpt.com/codex/tasks/task_e_6909ec11ac54832e99169c99ffae3e7d