### PR TITLE
Add animated status spinner to setup reporter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -319,7 +319,7 @@ def main() -> None:
         ("Firefox configuration", configure_firefox_phase),
     ]
 
-    reporter = StepReporter()
+    reporter = StepReporter(total_top_level=len(phases))
     try:
         with reporter:
             for label, phase in phases:

--- a/utils/reporter.py
+++ b/utils/reporter.py
@@ -1,8 +1,84 @@
 from __future__ import annotations
 
+import sys
+import threading
+import time
 from dataclasses import dataclass, field
 from enum import Enum
+from itertools import cycle
 from typing import Callable, Dict, List, Optional
+
+
+class StatusAnimator:
+    """Render a lightweight spinner showing the current progress path."""
+
+    _FRAMES = tuple("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+    _INTERVAL = 0.1
+
+    def __init__(self, stream=None) -> None:
+        self._stream = stream or sys.stdout
+        self.enabled = bool(getattr(self._stream, "isatty", lambda: False)())
+        self._lock = threading.Lock()
+        self._status = ""
+        self._stop = threading.Event()
+        self._paused = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def pause(self) -> None:
+        if not self.enabled or self._thread is None:
+            return
+        self._paused.set()
+        with self._lock:
+            self._stream.write("\r\033[K")
+            self._stream.flush()
+
+    def resume(self, status: str) -> None:
+        if not self.enabled:
+            return
+        with self._lock:
+            self._status = status
+        self._paused.clear()
+        if self._thread is None:
+            self._stop.clear()
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+
+    def update(self, status: str) -> None:
+        if not self.enabled or self._thread is None:
+            return
+        with self._lock:
+            self._status = status
+
+    def stop(self, final_status: Optional[str] = None) -> None:
+        if not self.enabled:
+            return
+        if self._thread is not None:
+            self._stop.set()
+            self._paused.clear()
+            self._thread.join()
+            self._thread = None
+        with self._lock:
+            self._stream.write("\r\033[K")
+            if final_status:
+                self._stream.write(final_status)
+                if not final_status.endswith("\n"):
+                    self._stream.write("\n")
+            self._stream.flush()
+
+    def _run(self) -> None:
+        frames = cycle(self._FRAMES)
+        while not self._stop.is_set():
+            if self._paused.is_set():
+                time.sleep(self._INTERVAL)
+                continue
+            frame = next(frames)
+            with self._lock:
+                self._stream.write(f"\r{frame} {self._status}")
+                self._stream.flush()
+            time.sleep(self._INTERVAL)
+        with self._lock:
+            self._stream.write("\r\033[K")
+            self._stream.flush()
 
 
 class StepStatus(str, Enum):
@@ -35,10 +111,19 @@ class Step:
 class StepReporter:
     """Collects hierarchical step information and renders progress messages."""
 
-    def __init__(self, printer: Callable[[str], None] | None = None) -> None:
+    def __init__(
+        self,
+        printer: Callable[[str], None] | None = None,
+        *,
+        total_top_level: Optional[int] = None,
+    ) -> None:
         self._print = printer or print
         self._root = Step(name="__root__", depth=-1)
         self._stack: List[Step] = [self._root]
+        self._animator = None if printer else StatusAnimator()
+        self._total_top_level = total_top_level or 0
+        self._completed_top_level = 0
+        self._animator_finalized = False
 
     def __enter__(self) -> "StepReporter":
         return self
@@ -51,6 +136,8 @@ class StepReporter:
                 if step.status is StepStatus.PENDING:
                     step.status = StepStatus.FAILED
                     step.error = message
+        if self._animator and not self._animator_finalized:
+            self._animator.stop()
         return False
 
     # Public API ---------------------------------------------------------
@@ -59,24 +146,37 @@ class StepReporter:
         step = Step(name=name, parent=parent, depth=len(self._stack) - 1)
         parent.children.append(step)
         self._stack.append(step)
+        self._before_output()
         self._print(f"{'  ' * step.depth}▶ {name}")
+        self._after_step_change()
 
     def finish_step(self, name: str) -> None:
         step = self._end_step(name)
         if step.status is StepStatus.FAILED:
             return
         step.status = StepStatus.SUCCESS
+        self._before_output()
         self._print(f"{'  ' * step.depth}✔ {name}")
+        if step.depth == 0:
+            self._completed_top_level += 1
+        self._after_step_change()
 
     def fail_step(self, name: str, error: Exception | str) -> None:
         step = self._end_step(name)
         step.status = StepStatus.FAILED
         step.error = str(error)
+        self._before_output()
         self._print(f"{'  ' * step.depth}✖ {name}: {step.error}")
+        if self._animator:
+            failure_status = f"✖ {self._format_path([s.name for s in self._stack[1:]] + [name])}"
+            self._animator.stop(failure_status)
+            self._animator_finalized = True
 
     def log(self, message: str) -> None:
         indent_level = max(len(self._stack) - 2, 0)
+        self._before_output()
         self._print(f"{'  ' * indent_level}- {message}")
+        self._after_step_change()
 
     def summary(self) -> Dict[str, List[Dict[str, Optional[str]]]]:
         succeeded: List[Dict[str, Optional[str]]] = []
@@ -94,6 +194,43 @@ class StepReporter:
         return {"succeeded": succeeded, "failed": failed}
 
     # Internal helpers ---------------------------------------------------
+    def _before_output(self) -> None:
+        if self._animator:
+            self._animator.pause()
+
+    def _after_step_change(self) -> None:
+        if not self._animator:
+            return
+        status = self._current_status()
+        if status:
+            self._animator.resume(status)
+        elif len(self._stack) <= 1:
+            if self._total_top_level and self._completed_top_level >= self._total_top_level:
+                final = f"✔ [{self._total_top_level}/{self._total_top_level}] All phases complete"
+                self._animator.stop(final)
+                self._animator_finalized = True
+            elif self._completed_top_level:
+                self._animator.stop("✔ All phases complete")
+                self._animator_finalized = True
+            else:
+                self._animator.pause()
+        else:
+            self._animator.pause()
+
+    def _current_status(self) -> str:
+        if len(self._stack) <= 1:
+            return ""
+        path = [step.name for step in self._stack[1:]]
+        prefix = ""
+        if self._total_top_level:
+            current_index = min(self._completed_top_level + 1, self._total_top_level)
+            prefix = f"[{current_index}/{self._total_top_level}] "
+        return prefix + self._format_path(path)
+
+    @staticmethod
+    def _format_path(path: List[str]) -> str:
+        return " › ".join(path)
+
     def _end_step(self, name: str) -> Step:
         if len(self._stack) <= 1:
             raise RuntimeError("Cannot finish a step when no steps are active.")


### PR DESCRIPTION
## Summary
- introduce a `StatusAnimator` helper so the step reporter can render a live spinner with the active phase path
- pause and resume the spinner around step output to keep logs clean and stop with a final completion or failure message
- wire the total phase count into the reporter to show overall progress while running `setup.py`

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_6909ef8fbc54832e974fe6e39980f2a4