### PR TITLE
Add interactive guidance for git configuration step

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -217,6 +217,12 @@ def configure_developer_tooling_phase(reporter: StepReporter) -> None:
         with managed_step(reporter, "Configure VS Code"):
             configure_vscode()
         with managed_step(reporter, "Configure Git"):
+            if sys.stdin.isatty():
+                reporter.log(
+                    "Configuring git identities interactively. Answer the prompts that appear to continue."
+                )
+            else:
+                reporter.log("Configuring git identities (non-interactive mode).")
             configure_git()
         with managed_step(reporter, "Configure SSH"):
             configure_ssh()


### PR DESCRIPTION
## Summary
- log a message before configuring git to explain that prompts may appear
- clarify the non-interactive execution path when stdin is not a tty

## Testing
- python -m compileall setup.py

------
https://chatgpt.com/codex/tasks/task_e_6909f3828004832e83bdddb85d2e2406