### PR TITLE
Adjust spinner pulse placement

### DIFF
--- a/utils/reporter.py
+++ b/utils/reporter.py
@@ -109,7 +109,7 @@ class StatusAnimator:
             with self._lock:
                 if pulse:
                     self._stream.write(
-                        f"\r{self._theme.accent}{frame}{pulse} {self._status}{nailpolish.RESET}"
+                        f"\r{self._theme.accent}{frame} {self._status}{pulse}{nailpolish.RESET}"
                     )
                 else:
                     self._stream.write(


### PR DESCRIPTION
## Summary
- move the animated ellipsis to the end of the status message so it no longer overlaps the spinner glyph

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_6909f839325c832e83346724b3ac28a2