### PR TITLE
Refresh status animator glow effect

### DIFF
--- a/shell/nailpolish.py
+++ b/shell/nailpolish.py
@@ -10,6 +10,11 @@ RED = "\033[38;2;230;130;130m"
 PINK = "\033[38;2;255;166;210m"
 RESET = "\033[0m"
 GRAY = "\033[38;2;122;132;164m"
+
+# Text intensity modifiers for gentle glow effects.
+DIM = "\033[2m"
+NORMAL = "\033[22m"
+BRIGHT = "\033[1m"
 NEWLINE = "\n"
 
 # Set up logging with custom formatting

--- a/utils/reporter.py
+++ b/utils/reporter.py
@@ -41,7 +41,12 @@ class StatusAnimator:
     _FRAMES = tuple("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
     _INTERVAL = 0.1
 
-    _PULSE_FRAMES = ("   ", ".  ", ".. ", "...")
+    _GLOW_STYLES = (
+        nailpolish.DIM,
+        nailpolish.NORMAL,
+        nailpolish.BRIGHT,
+        nailpolish.NORMAL,
+    )
 
     def __init__(self, theme: Theme, stream=None, *, pulse_enabled: bool = True) -> None:
         self._theme = theme
@@ -99,22 +104,17 @@ class StatusAnimator:
 
     def _run(self) -> None:
         frames = cycle(self._FRAMES)
-        pulses = cycle(self._PULSE_FRAMES) if self._pulse_enabled else None
+        glow_styles = cycle(self._GLOW_STYLES) if self._pulse_enabled else None
         while not self._stop.is_set():
             if self._paused.is_set():
                 time.sleep(self._INTERVAL)
                 continue
             frame = next(frames)
-            pulse = next(pulses) if pulses else ""
+            style = next(glow_styles) if glow_styles else ""
             with self._lock:
-                if pulse:
-                    self._stream.write(
-                        f"\r{self._theme.accent}{frame} {self._status}{pulse}{nailpolish.RESET}"
-                    )
-                else:
-                    self._stream.write(
-                        f"\r{self._theme.accent}{frame} {self._status}{nailpolish.RESET}"
-                    )
+                self._stream.write(
+                    f"\r{self._theme.accent}{frame} {style}{self._status}{nailpolish.RESET}"
+                )
                 self._stream.flush()
             time.sleep(self._INTERVAL)
         with self._lock:


### PR DESCRIPTION
## Summary
- replace the status pulse dots with a glow-style cycle in `StatusAnimator`
- add dim, normal, and bright intensity modifiers to the nailpolish palette for reuse

## Testing
- python - <<'PY'
import io
import time

from utils.reporter import FrecklesTheme, StatusAnimator


class Buffer(io.StringIO):
    def isatty(self):
        return True

    def flush(self):
        pass


stream = Buffer()
animator = StatusAnimator(FrecklesTheme.build(), stream=stream)
animator.resume("glow test")
# Allow a few frames to render.
time.sleep(0.45)
animator.stop()
out = stream.getvalue()
print("has dots:", "..." in out)
print("dim present:", "\u001b[2m" in out)
print("bright present:", "\u001b[1m" in out)
PY

------
https://chatgpt.com/codex/tasks/task_e_6909fa6b8e3c832e9ab0880dbac7f516