### PR TITLE
Ensure StepReporter animation finalizes once

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utils.reporter import StepReporter
+
+
+class _DummyAnimator:
+    def __init__(self) -> None:
+        self.calls: List[Tuple[str, Optional[str]]] = []
+
+    def pause(self) -> None:
+        self.calls.append(("pause", None))
+
+    def resume(self, status: str) -> None:
+        self.calls.append(("resume", status))
+
+    def stop(self, final_status: Optional[str] = None) -> None:
+        self.calls.append(("stop", final_status))
+
+
+def test_interactive_section_pauses_and_resumes() -> None:
+    outputs: List[str] = []
+    reporter = StepReporter(printer=outputs.append)
+    reporter._animator = _DummyAnimator()
+
+    with reporter:
+        reporter.start_step("phase")
+        reporter._animator.calls.clear()
+
+        with reporter.interactive_section():
+            pass
+
+        assert reporter._animator.calls[0] == ("pause", None)
+        assert reporter._animator.calls[1][0] == "resume"
+        assert reporter._animator.calls[1][1]
+
+        reporter.finish_step("phase")
+
+
+def test_final_message_emitted_once_without_total() -> None:
+    outputs: List[str] = []
+    reporter = StepReporter(printer=outputs.append)
+    reporter._animator = _DummyAnimator()
+
+    with reporter:
+        reporter.start_step("phase")
+        reporter.finish_step("phase")
+
+        stop_calls = [call for call in reporter._animator.calls if call[0] == "stop"]
+        assert not stop_calls
+        assert reporter._animator_finalized is False
+
+    stop_calls = [call for call in reporter._animator.calls if call[0] == "stop"]
+    assert len(stop_calls) == 1
+    assert "All phases complete" in (stop_calls[0][1] or "")
+    assert reporter._animator_finalized is True
+
+
+def test_final_message_emitted_when_total_complete() -> None:
+    outputs: List[str] = []
+    reporter = StepReporter(printer=outputs.append, total_top_level=1)
+    reporter._animator = _DummyAnimator()
+
+    with reporter:
+        reporter.start_step("phase")
+        reporter.finish_step("phase")
+
+        stop_calls = [call for call in reporter._animator.calls if call[0] == "stop"]
+        assert len(stop_calls) == 1
+        assert "[1/1]" in (stop_calls[0][1] or "")
+        assert reporter._animator_finalized is True
+
+    stop_calls = [call for call in reporter._animator.calls if call[0] == "stop"]
+    assert len(stop_calls) == 1

--- a/utils/reporter.py
+++ b/utils/reporter.py
@@ -191,7 +191,7 @@ class StepReporter:
                     step.status = StepStatus.FAILED
                     step.error = message
         if self._animator and not self._animator_finalized:
-            self._animator.stop()
+            self._finalize_animation()
         return False
 
     # Public API ---------------------------------------------------------
@@ -300,14 +300,7 @@ class StepReporter:
             self._animator.resume(status)
         elif len(self._stack) <= 1:
             if self._total_top_level and self._completed_top_level >= self._total_top_level:
-                final = f"✔ [{self._total_top_level}/{self._total_top_level}] All phases complete"
-                self._animator.stop(self._colorize(self._theme.success, final))
-                self._animator_finalized = True
-            elif self._completed_top_level:
-                self._animator.stop(
-                    self._colorize(self._theme.success, "✔ All phases complete")
-                )
-                self._animator_finalized = True
+                self._finalize_animation()
             else:
                 self._animator.pause()
         else:
@@ -343,3 +336,22 @@ class StepReporter:
         remaining = self._min_step_duration - elapsed
         if remaining > 0:
             time.sleep(remaining)
+
+    def _finalize_animation(self) -> None:
+        if not self._animator or self._animator_finalized:
+            return
+        final_status = self._final_status_message()
+        self._animator.stop(final_status)
+        self._animator_finalized = True
+
+    def _final_status_message(self) -> Optional[str]:
+        if not self._animator:
+            return None
+        if self._total_top_level:
+            if self._completed_top_level >= self._total_top_level:
+                final = f"✔ [{self._total_top_level}/{self._total_top_level}] All phases complete"
+                return self._colorize(self._theme.success, final)
+            return None
+        if self._completed_top_level:
+            return self._colorize(self._theme.success, "✔ All phases complete")
+        return None


### PR DESCRIPTION
## Summary
- keep the StepReporter animator paused when no total is defined so additional phases can reuse it
- centralize animator finalization so the completion message is emitted exactly once at the end of the run
- add unit tests covering interactive sections and completion behaviour while ensuring the test suite can import project modules after changing directories

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6909ff0715a0832e8ef5011f6102e701