### PR TITLE
Fix status animator spinner line clearing

### DIFF
--- a/utils/reporter.py
+++ b/utils/reporter.py
@@ -113,8 +113,9 @@ class StatusAnimator:
             frame = next(frames)
             style = next(glow_styles) if glow_styles else ""
             with self._lock:
+                self._stream.write("\r\033[K")
                 self._stream.write(
-                    f"\r{self._theme.accent}{frame} {style}{self._status}{nailpolish.RESET}"
+                    f"{self._theme.accent}{frame} {style}{self._status}{nailpolish.RESET}"
                 )
                 self._stream.flush()
             time.sleep(self._INTERVAL)


### PR DESCRIPTION
## Summary
- clear the spinner line before writing each frame to avoid leftover characters
- ensure the stop path keeps clearing and resetting the line after the animation ends

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690a0094dafc832ebe4953bf330d1a16