### PR TITLE
Improve installer prompt reporting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -249,7 +249,8 @@ def manage_avatar_phase(reporter: StepReporter) -> None:
 
 def configure_calibre_phase(reporter: StepReporter) -> None:
     with managed_step(reporter, "Configure Calibre"):
-        configure_calibre()
+        with reporter.interactive_section():
+            configure_calibre()
 
 
 def upgrade_bookworm_phase(reporter: StepReporter) -> None:

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -8,7 +9,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from utils.reporter import StepReporter
+from utils.reporter import StepReporter, Theme
 
 
 class _DummyAnimator:
@@ -42,6 +43,41 @@ def test_interactive_section_pauses_and_resumes() -> None:
         assert reporter._animator.calls[1][1]
 
         reporter.finish_step("phase")
+
+
+def test_interactive_prompts_render_within_story() -> None:
+    outputs: List[str] = []
+    reporter = StepReporter(
+        printer=outputs.append,
+        theme=Theme(accent="", success="", failure="", log=""),
+        enable_animation=False,
+    )
+
+    with reporter:
+        reporter.start_step("phase")
+
+        original_input = builtins.input
+        responses = iter(["keep"])
+        prompts: List[str] = []
+
+        def stub_input(prompt: str = "") -> str:
+            prompts.append(prompt)
+            return next(responses)
+
+        builtins.input = stub_input
+        try:
+            with reporter.interactive_section():
+                answer = input("Choose option [keep]: ")
+        finally:
+            builtins.input = original_input
+
+        assert answer == "keep"
+
+        reporter.finish_step("phase")
+
+    prompt_lines = [line for line in outputs if line.startswith("? ")]
+    assert prompt_lines == ["? Choose option [keep]:"]
+    assert prompts == ["> "]
 
 
 def test_final_message_emitted_once_without_total() -> None:

--- a/utils/reporter.py
+++ b/utils/reporter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import sys
 import threading
 import time
@@ -179,6 +180,8 @@ class StepReporter:
         self._total_top_level = total_top_level or 0
         self._completed_top_level = 0
         self._animator_finalized = False
+        self._input_patch_depth = 0
+        self._original_input: Optional[Callable[[str], str]] = None
 
     def __enter__(self) -> "StepReporter":
         return self
@@ -248,24 +251,25 @@ class StepReporter:
     def interactive_section(self):
         """Temporarily pause the status animation for interactive prompts."""
 
-        if not self._animator or self._animator_finalized:
-            yield
-            return
+        with self._patched_input():
+            if not self._animator or self._animator_finalized:
+                yield
+                return
 
-        self._animator.pause()
-        try:
-            yield
-        except Exception:
-            if self._animator and not self._animator_finalized:
-                self._animator.pause()
-            raise
-        else:
-            if self._animator and not self._animator_finalized:
-                status = self._current_status()
-                if status:
-                    self._animator.resume(status)
-                else:
+            self._animator.pause()
+            try:
+                yield
+            except Exception:
+                if self._animator and not self._animator_finalized:
                     self._animator.pause()
+                raise
+            else:
+                if self._animator and not self._animator_finalized:
+                    status = self._current_status()
+                    if status:
+                        self._animator.resume(status)
+                    else:
+                        self._animator.pause()
 
     def summary(self) -> Dict[str, List[Dict[str, Optional[str]]]]:
         succeeded: List[Dict[str, Optional[str]]] = []
@@ -356,3 +360,32 @@ class StepReporter:
         if self._completed_top_level:
             return self._colorize(self._theme.success, "✔ All phases complete")
         return None
+
+    @contextmanager
+    def _patched_input(self):
+        if self._input_patch_depth == 0:
+            self._original_input = builtins.input
+
+            def prompt_input(message: object = "") -> str:
+                return self._handle_prompt_input(message)
+
+            builtins.input = prompt_input  # type: ignore[assignment]
+        self._input_patch_depth += 1
+        try:
+            yield
+        finally:
+            self._input_patch_depth -= 1
+            if self._input_patch_depth == 0 and self._original_input is not None:
+                builtins.input = self._original_input  # type: ignore[assignment]
+                self._original_input = None
+
+    def _handle_prompt_input(self, message: object) -> str:
+        text = str(message).rstrip()
+        if text:
+            indent_level = max(len(self._stack) - 2, 0)
+            indent = "  " * indent_level
+            self._before_output()
+            self._print(self._colorize(self._theme.accent, f"{indent}? {text}"))
+        if self._original_input is None:
+            raise RuntimeError("Interactive prompt invoked outside managed context.")
+        return self._original_input("> ")


### PR DESCRIPTION
## Summary
- teach `StepReporter` to instrument `input()` so interactive prompts show up as part of the installer story output
- wrap the Calibre configuration phase in an interactive section so its questions are rendered consistently
- extend the reporter tests to cover the new prompt handling behaviour

## Testing
- python3 -m pytest *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_690a02080170832ebf9afa70e0b13c92