### PR TITLE
Avoid interactive sudo prompts during setup

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -36,8 +36,9 @@ def _fake_run(commands):
             if path.exists():
                 path.chmod(0o644)
             return FakeProcess()
-        if "sudo cat" in command:
-            target = Path(command.split()[2])
+        parts = command.split()
+        if len(parts) >= 4 and parts[0] == "sudo" and parts[2] == "cat":
+            target = Path(parts[3])
             return FakeProcess(stdout=target.read_text() if target.exists() else "")
         return FakeProcess()
 
@@ -82,7 +83,7 @@ def test_configure_repository_is_idempotent(monkeypatch):
     assert commands, "Expected the repository key to be refreshed on subsequent runs"
     assert commands[0] == expected_gpg_command
     if len(commands) == 2:
-        assert commands[1] == f"sudo {expected_gpg_command}"
+        assert commands[1] == f"sudo -n {expected_gpg_command}"
     else:
         assert len(commands) == 1
 

--- a/utils/debian.py
+++ b/utils/debian.py
@@ -30,9 +30,25 @@ class DebRepository:
     gpg_template: Optional[str] = None
 
 
+def _ensure_non_interactive_sudo(command: str) -> str:
+    """Insert ``-n`` into ``sudo`` invocations to avoid interactive prompts."""
+
+    stripped = command.lstrip()
+    if not stripped.startswith("sudo"):
+        return command
+
+    if "sudo -n" in command or "sudo --non-interactive" in command:
+        return command
+
+    prefix_len = len(command) - len(stripped)
+    suffix = stripped[len("sudo") :]
+    return command[:prefix_len] + "sudo -n" + suffix
+
+
 def run(command: str) -> subprocess.CompletedProcess[str]:
     """Execute ``command`` via ``subprocess.run`` with output capture enabled."""
 
+    command = _ensure_non_interactive_sudo(command)
     return subprocess.run(command, capture_output=True, text=True, shell=True)
 
 


### PR DESCRIPTION
## Summary
- ensure the shared run helper forces sudo to run in non-interactive mode
- adjust web utility tests to match the updated sudo invocation

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_690a0eec4114832ea0b59f1a23e6d3e5