### PR TITLE
Fix apt-get update command usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ def emit_summary(summary: Dict[str, List[Dict[str, Optional[str]]]]) -> None:
 
 def refresh_apt_phase(reporter: StepReporter) -> None:
     with managed_step(reporter, "Run apt-get update"):
-        apt_update_result = run("sudo apt-get update -yqq")
+        apt_update_result = run("sudo apt-get update -qq")
         if apt_update_result.returncode != 0:
             combined_output = (apt_update_result.stderr or "") + (apt_update_result.stdout or "")
             if "NO_PUBKEY" in combined_output:
@@ -178,7 +178,7 @@ def refresh_apt_phase(reporter: StepReporter) -> None:
                 with managed_step(reporter, "Refresh repository keys"):
                     refresh_keys()
 
-                apt_update_result = run("sudo apt-get update -yqq")
+                apt_update_result = run("sudo apt-get update -qq")
 
             if apt_update_result.returncode != 0:
                 message = (apt_update_result.stderr or "").strip() or (apt_update_result.stdout or "").strip()

--- a/utils/web.py
+++ b/utils/web.py
@@ -260,7 +260,7 @@ def refresh_repository_keys(
 
 
 def install_software_list(software_list: List[Union[DebFile, DebRepository]]):
-    update_result = run("sudo apt-get update -yqq")
+    update_result = run("sudo apt-get update -qq")
     _ensure_success(update_result, "Failed to refresh apt package lists")
 
     for software in software_list:
@@ -286,7 +286,7 @@ def install_software_list(software_list: List[Union[DebFile, DebRepository]]):
             get_and_install_from_download_link(software.direct_link, software.name)
         elif isinstance(software, DebRepository):
             _configure_repository(software)
-            update_result = run("sudo apt-get update -yqq")
+            update_result = run("sudo apt-get update -qq")
             _ensure_success(update_result, f"Failed to update apt cache for {software.name}")
             print(f"installing {software.name}")
             install_result = install_with_apt([software.install_name or software.name])


### PR DESCRIPTION
## Summary
- remove the unsupported -y flag from automated apt-get update calls
- ensure both setup and web installers refresh package lists with valid options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690bd28d01bc832ea445bbf5103889c0